### PR TITLE
feat: 쿠폰 서비스 기본 세팅 및 생성 API 구현

### DIFF
--- a/config/src/main/resources/config-repo/coupon-service.yml
+++ b/config/src/main/resources/config-repo/coupon-service.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:

--- a/config/src/main/resources/config-repo/coupon-service.yml
+++ b/config/src/main/resources/config-repo/coupon-service.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: coupon-service
   datasource:
-    url: jdbc:mysql://mysql:3306/coupon_service?serverTimezone=UTC&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/coupon_service?serverTimezone=UTC&characterEncoding=UTF-8
     username: root
     password: admin1234
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -22,6 +22,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+    // maven { url 'https://jitpack.io' }
 }
 
 ext {
@@ -29,6 +30,10 @@ ext {
 }
 
 dependencies {
+
+    // common todo 재연결
+    // implementation 'com.github.sharedeffort:common-module:v1.1.7'
+    // implementation 'com.github.sharedeffort:common-jpa:v1.0.0'
 
     // spring cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-config'

--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -22,7 +22,7 @@ configurations {
 
 repositories {
 	mavenCentral()
-    // maven { url 'https://jitpack.io' }
+    maven { url 'https://jitpack.io' }
 }
 
 ext {
@@ -31,9 +31,9 @@ ext {
 
 dependencies {
 
-    // common todo 재연결
-    // implementation 'com.github.sharedeffort:common-module:v1.1.7'
-    // implementation 'com.github.sharedeffort:common-jpa:v1.0.0'
+    // common
+    implementation 'com.github.sharedeffort:common-module:v1.1.8'
+    implementation 'com.github.sharedeffort:common-jpa:v1.0.1'
 
     // spring cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-config'

--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -29,11 +29,23 @@ ext {
 }
 
 dependencies {
+
+    // spring cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // spring boot
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+    // db
     runtimeOnly 'com.mysql:mysql-connector-j'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/coupon/src/main/java/com/high/coupon/CouponApplication.java
+++ b/coupon/src/main/java/com/high/coupon/CouponApplication.java
@@ -2,7 +2,9 @@ package com.high.coupon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CouponApplication {
 

--- a/coupon/src/main/java/com/high/coupon/application/CouponService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponService.java
@@ -17,6 +17,8 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
 
+    // todo : 권한 검증 필요
+
     // 쿠폰 등록
     @Transactional
     public CouponCreateResponse createCoupon(CouponCreateRequest request){

--- a/coupon/src/main/java/com/high/coupon/application/CouponService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponService.java
@@ -1,5 +1,9 @@
 package com.high.coupon.application;
 
+import com.high.coupon.application.dto.request.CouponCreateRequest;
+import com.high.coupon.application.dto.response.CouponCreateResponse;
+import com.high.coupon.domain.entity.Coupon;
+import com.high.coupon.domain.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,5 +15,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CouponService {
 
-    // todo 로직 작성
+    private final CouponRepository couponRepository;
+
+    // 쿠폰 등록
+    @Transactional
+    public CouponCreateResponse createCoupon(CouponCreateRequest request){
+
+        Coupon coupon = Coupon.createCoupon(
+                request.name(),
+                request.description(),
+                request.discountRate(),
+                request.totalQuantity(),
+                request.issueStartAt(),
+                request.issueEndAt(),
+                request.validUntil()
+        );
+
+        Coupon savedCoupon = couponRepository.save(coupon);
+        return CouponCreateResponse.from(savedCoupon);
+    }
 }

--- a/coupon/src/main/java/com/high/coupon/application/CouponService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponService.java
@@ -1,0 +1,15 @@
+package com.high.coupon.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class CouponService {
+
+    // todo 로직 작성
+}

--- a/coupon/src/main/java/com/high/coupon/application/dto/request/CouponCreateRequest.java
+++ b/coupon/src/main/java/com/high/coupon/application/dto/request/CouponCreateRequest.java
@@ -1,0 +1,41 @@
+package com.high.coupon.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record CouponCreateRequest(
+
+        @NotBlank(message = "쿠폰 이름을 입력해주세요.")
+        String name,
+
+        @NotBlank(message = "쿠폰 정책(설명)을 입력해주세요.")
+        String description,
+
+        @NotNull(message = "할인율을 입력해주세요")
+        @DecimalMin(value = "0.0", inclusive = true, message = "할인율은 0% 이상이어야 합니다.")
+        @DecimalMax(value = "100.0", inclusive = true, message = "할인율은 100% 이하여야 합니다.")
+        BigDecimal discountRate,
+
+        @NotNull(message = "총 발행 수량을 입력해주세요.")
+        @PositiveOrZero(message = "총 발행 수량은 0 이상이어야 합니다.")
+        Integer totalQuantity,
+
+        @NotNull(message = "발행 시작일을 입력해주세요.")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime issueStartAt,
+
+        @NotNull(message = "발행 종료일을 입력해주세요.")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime issueEndAt,
+
+        @NotNull(message = "쿠폰 만료일을 입력해주세요.")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime validUntil
+) {
+}

--- a/coupon/src/main/java/com/high/coupon/application/dto/response/CouponCreateResponse.java
+++ b/coupon/src/main/java/com/high/coupon/application/dto/response/CouponCreateResponse.java
@@ -12,7 +12,10 @@ public record CouponCreateResponse(
         BigDecimal discountRate,
         LocalDateTime issueStartAt,
         LocalDateTime issueEndAt,
-        LocalDateTime validUntil
+        LocalDateTime validUntil,
+        LocalDateTime createdAt,
+        // todo createdBy 타입 확인
+        String createdBy
 ) {
     public static CouponCreateResponse from(Coupon coupon){
         return new CouponCreateResponse(
@@ -22,7 +25,9 @@ public record CouponCreateResponse(
                 coupon.getDiscountRate(),
                 coupon.getIssueStartAt(),
                 coupon.getIssueEndAt(),
-                coupon.getValidUntil()
+                coupon.getValidUntil(),
+                coupon.getCreatedAt(),
+                coupon.getCreatedBy()
         );
     }
 }

--- a/coupon/src/main/java/com/high/coupon/application/dto/response/CouponCreateResponse.java
+++ b/coupon/src/main/java/com/high/coupon/application/dto/response/CouponCreateResponse.java
@@ -1,0 +1,28 @@
+package com.high.coupon.application.dto.response;
+
+import com.high.coupon.domain.entity.Coupon;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CouponCreateResponse(
+        UUID id,
+        String name,
+        String description,
+        BigDecimal discountRate,
+        LocalDateTime issueStartAt,
+        LocalDateTime issueEndAt,
+        LocalDateTime validUntil
+) {
+    public static CouponCreateResponse from(Coupon coupon){
+        return new CouponCreateResponse(
+                coupon.getId(),
+                coupon.getName(),
+                coupon.getDescription(),
+                coupon.getDiscountRate(),
+                coupon.getIssueStartAt(),
+                coupon.getIssueEndAt(),
+                coupon.getValidUntil()
+        );
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/config/TestAuditorAware.java
+++ b/coupon/src/main/java/com/high/coupon/config/TestAuditorAware.java
@@ -1,0 +1,16 @@
+package com.high.coupon.config;
+
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * 개발용 임시 값 config -> 유저 쪽 개발되면 삭제
+ */
+@Component
+public class TestAuditorAware implements AuditorAware<String> {
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        return Optional.of("test-user"); // 테스트 유저 임시값 -> UUID 변경 필요
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/domain/entity/Coupon.java
+++ b/coupon/src/main/java/com/high/coupon/domain/entity/Coupon.java
@@ -42,8 +42,42 @@ public class Coupon {
     @Column(nullable = false)
     private LocalDateTime issueStartAt;
 
+    @Column(nullable = false)
     private LocalDateTime issueEndAt;
 
     @Column(nullable = false)
     private LocalDateTime validUntil;
+
+
+    /**
+     * 쿠폰 생성
+     */
+    public static Coupon createCoupon(String name, String description, BigDecimal discountRate,
+            Integer totalQuantity, LocalDateTime issueStartAt, LocalDateTime issueEndAt, LocalDateTime validUntil){
+
+        validateDates(issueStartAt, issueEndAt, validUntil);
+
+        return Coupon.builder()
+                .name(name)
+                .description(description)
+                .discountRate(discountRate)
+                .totalQuantity(totalQuantity)
+                .issueStartAt(issueStartAt)
+                .issueEndAt(issueEndAt)
+                .validUntil(validUntil)
+                .build();
+    }
+
+    /**
+     * 날짜 검증 메서드
+     * todo: 예외처리 임시 작성
+     */
+    private static void validateDates(LocalDateTime issueStartAt, LocalDateTime issueEndAt, LocalDateTime validUntil) {
+        if (issueStartAt == null)
+            throw new IllegalArgumentException("발행 시작일은 필수입니다.");
+        if (issueEndAt != null && issueEndAt.isBefore(issueStartAt))
+            throw new IllegalArgumentException("발행 종료일은 시작일 이후여야 합니다.");
+        if (validUntil.isBefore(issueStartAt))
+            throw new IllegalArgumentException("유효기간 종료일은 발행 시작일 이후여야 합니다.");
+    }
 }

--- a/coupon/src/main/java/com/high/coupon/domain/entity/Coupon.java
+++ b/coupon/src/main/java/com/high/coupon/domain/entity/Coupon.java
@@ -1,5 +1,6 @@
 package com.high.coupon.domain.entity;
 
+import com.library.jpa.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "p_coupon")
-public class Coupon {
+public class Coupon extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -47,7 +48,6 @@ public class Coupon {
 
     @Column(nullable = false)
     private LocalDateTime validUntil;
-
 
     /**
      * 쿠폰 생성

--- a/coupon/src/main/java/com/high/coupon/domain/entity/Coupon.java
+++ b/coupon/src/main/java/com/high/coupon/domain/entity/Coupon.java
@@ -1,0 +1,49 @@
+package com.high.coupon.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "p_coupon")
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false, precision = 5, scale = 2)
+    private BigDecimal discountRate;
+
+    @Column(nullable = false)
+    private Integer totalQuantity;
+
+    @Column(nullable = false)
+    private LocalDateTime issueStartAt;
+
+    private LocalDateTime issueEndAt;
+
+    @Column(nullable = false)
+    private LocalDateTime validUntil;
+}

--- a/coupon/src/main/java/com/high/coupon/domain/entity/CouponIssue.java
+++ b/coupon/src/main/java/com/high/coupon/domain/entity/CouponIssue.java
@@ -1,0 +1,57 @@
+package com.high.coupon.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "p_coupon_issue",
+    uniqueConstraints = {
+        @UniqueConstraint(
+                columnNames = {"coupon_id", "user_id"}
+        )
+})
+public class CouponIssue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private LocalDateTime issuedAt;
+
+    private Boolean isUsed = false;
+
+    private LocalDateTime usedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime validStartAt;
+
+    @Column(nullable = false)
+    private LocalDateTime validEndAt;
+}

--- a/coupon/src/main/java/com/high/coupon/domain/entity/CouponIssue.java
+++ b/coupon/src/main/java/com/high/coupon/domain/entity/CouponIssue.java
@@ -1,5 +1,6 @@
 package com.high.coupon.domain.entity;
 
+import com.library.jpa.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -29,7 +30,7 @@ import lombok.NoArgsConstructor;
                 columnNames = {"coupon_id", "user_id"}
         )
 })
-public class CouponIssue {
+public class CouponIssue extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/coupon/src/main/java/com/high/coupon/domain/repository/CouponIssueRepository.java
+++ b/coupon/src/main/java/com/high/coupon/domain/repository/CouponIssueRepository.java
@@ -1,0 +1,5 @@
+package com.high.coupon.domain.repository;
+
+public interface CouponIssueRepository {
+
+}

--- a/coupon/src/main/java/com/high/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/high/coupon/domain/repository/CouponRepository.java
@@ -1,4 +1,8 @@
 package com.high.coupon.domain.repository;
 
+import com.high.coupon.domain.entity.Coupon;
+
 public interface CouponRepository {
+
+    Coupon save(Coupon coupon);
 }

--- a/coupon/src/main/java/com/high/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/high/coupon/domain/repository/CouponRepository.java
@@ -1,0 +1,4 @@
+package com.high.coupon.domain.repository;
+
+public interface CouponRepository {
+}

--- a/coupon/src/main/java/com/high/coupon/exception/CouponErrorCode.java
+++ b/coupon/src/main/java/com/high/coupon/exception/CouponErrorCode.java
@@ -1,0 +1,10 @@
+package com.high.coupon.exception;
+
+public enum CouponErrorCode {
+
+    // todo 작성 필요
+
+    // application
+
+    // domain
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponIssueRepositoryAdaptor.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponIssueRepositoryAdaptor.java
@@ -8,4 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class CouponIssueRepositoryAdaptor implements CouponIssueRepository {
 
+    // todo: 쿠폰 생성 - 조회 기본 구현 완료 후 발급 이력 개발
+    private final JpaCouponIssueRepository jpaCouponIssueRepository;
+
 }

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponIssueRepositoryAdaptor.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponIssueRepositoryAdaptor.java
@@ -1,0 +1,11 @@
+package com.high.coupon.infrastructure.persistence;
+
+import com.high.coupon.domain.repository.CouponIssueRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CouponIssueRepositoryAdaptor implements CouponIssueRepository {
+
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponRepositoryAdaptor.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponRepositoryAdaptor.java
@@ -1,0 +1,13 @@
+package com.high.coupon.infrastructure.persistence;
+
+import com.high.coupon.domain.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CouponRepositoryAdaptor implements CouponRepository {
+
+    // private final JpaCouponRepository jpaCouponRepository;
+
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponRepositoryAdaptor.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponRepositoryAdaptor.java
@@ -1,5 +1,6 @@
 package com.high.coupon.infrastructure.persistence;
 
+import com.high.coupon.domain.entity.Coupon;
 import com.high.coupon.domain.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -8,6 +9,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class CouponRepositoryAdaptor implements CouponRepository {
 
-    // private final JpaCouponRepository jpaCouponRepository;
+    private final JpaCouponRepository jpaCouponRepository;
+
+    @Override
+    public Coupon save(Coupon coupon){
+        return jpaCouponRepository.save(coupon);
+    }
 
 }

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponIssueRepository.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponIssueRepository.java
@@ -1,0 +1,9 @@
+package com.high.coupon.infrastructure.persistence;
+
+import com.high.coupon.domain.entity.CouponIssue;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCouponIssueRepository extends JpaRepository<CouponIssue, UUID> {
+
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponIssueRepository.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponIssueRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaCouponIssueRepository extends JpaRepository<CouponIssue, UUID> {
 
+    // todo: 쿠폰 생성 - 조회 기본 구현 완료 후 발급 이력 개발
 }

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponRepository.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponRepository.java
@@ -1,0 +1,9 @@
+package com.high.coupon.infrastructure.persistence;
+
+import com.high.coupon.domain.entity.Coupon;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCouponRepository extends JpaRepository<Coupon, UUID> {
+
+}

--- a/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
@@ -1,0 +1,12 @@
+package com.high.coupon.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/coupons")
+public class CouponController {
+
+}

--- a/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
@@ -1,6 +1,14 @@
 package com.high.coupon.presentation;
 
+import com.high.coupon.application.CouponService;
+import com.high.coupon.application.dto.request.CouponCreateRequest;
+import com.high.coupon.application.dto.response.CouponCreateResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +17,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/coupons")
 public class CouponController {
 
+    private final CouponService couponService;
+
+    // todo 공통 모듈 적용 전 임시
+
+    // 쿠폰 등록
+    @PostMapping
+    public ResponseEntity<CouponCreateResponse> createCoupon(
+            @RequestBody @Valid CouponCreateRequest request){
+        var response = couponService.createCoupon(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 }

--- a/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
@@ -3,6 +3,7 @@ package com.high.coupon.presentation;
 import com.high.coupon.application.CouponService;
 import com.high.coupon.application.dto.request.CouponCreateRequest;
 import com.high.coupon.application.dto.response.CouponCreateResponse;
+import com.library.module.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,13 +20,13 @@ public class CouponController {
 
     private final CouponService couponService;
 
-    // todo 공통 모듈 적용 전 임시
+    // todo 권한 필요
 
-    // 쿠폰 등록
+    // 쿠폰 생성
     @PostMapping
-    public ResponseEntity<CouponCreateResponse> createCoupon(
+    public ResponseEntity<ApiResponse<CouponCreateResponse>> createCoupon(
             @RequestBody @Valid CouponCreateRequest request){
         var response = couponService.createCoupon(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 }


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #3 

## 📝 Description
- 쿠폰 서비스 패키지 분리
- 쿠폰, 쿠폰 이력 엔티티 추가
- 쿠폰 생성 api 구현
- ✅ 커스텀 예외 클래스 추가 예정

## 🌐 Test Result
<img width="978" height="862" alt="스크린샷 2025-12-01 182921" src="https://github.com/user-attachments/assets/b6a670dc-b468-43eb-a6ae-365735a09e0b" />


## 🔎 To Reviewer
- 패키지 계층, 파일명이 팀 컨벤션에 맞는 지 확인해주세요 ✋🏻
- BaseEntity에 createBy, updateBy 등이 String으로 되어있어서 일단 임시로 구현 해놨습니다. (수정 예정)
UUID로 바꾸려다.. 공통 모듈 반영 테스트를 어떻게 해야 할 지를 몰라서 뒷걸음질 쳤습니다..💦💦
- ApiResponse, ErrorCode 관련된 수정 제안 사항 노션에 백업해두겠습니다.
