### PR TITLE
feat: 쿠폰 조회 api 구현 (관리자용)

### DIFF
--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -32,7 +32,7 @@ ext {
 dependencies {
 
     // common
-    implementation 'com.github.sharedeffort:common-module:v1.1.8'
+    implementation 'com.github.sharedeffort:common-module:v1.1.9'
     implementation 'com.github.sharedeffort:common-jpa:v1.0.1'
 
     // spring cloud

--- a/coupon/src/main/java/com/high/coupon/CouponApplication.java
+++ b/coupon/src/main/java/com/high/coupon/CouponApplication.java
@@ -2,10 +2,12 @@ package com.high.coupon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ComponentScan(basePackages = {"com.high.coupon", "com.library.module"})
 public class CouponApplication {
 
 	public static void main(String[] args) {

--- a/coupon/src/main/java/com/high/coupon/application/CouponService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponService.java
@@ -7,10 +7,15 @@ import com.high.coupon.application.dto.response.CouponListResponse;
 import com.high.coupon.application.exception.CouponNotFoundException;
 import com.high.coupon.domain.entity.Coupon;
 import com.high.coupon.domain.repository.CouponRepository;
+import com.library.jpa.response.PageResponse;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,11 +54,11 @@ public class CouponService {
     }
 
     // 쿠폰 리스트 조회
-    public List<CouponListResponse> getAllCoupons() {
-        return couponRepository.findAll()
-                .stream()
-                .map(CouponListResponse::from)
-                .toList();
+    public PageResponse<CouponListResponse> getCouponPage(int page, int size, String sortBy, boolean isAsc) {
+        Pageable pageable = createPageable(page, size, sortBy, isAsc);
+        Page<Coupon> pageResult = couponRepository.findAll(pageable);
+        Page<CouponListResponse> couponList = pageResult.map(CouponListResponse::from);
+        return PageResponse.fromPage(couponList, sortBy, isAsc);
     }
 
     /**
@@ -62,5 +67,19 @@ public class CouponService {
     public Coupon getCouponById(UUID couponId){
         return couponRepository.findById(couponId)
                 .orElseThrow(CouponNotFoundException::new);
+    }
+
+    /**
+     * 쿠폰 페이징
+     */
+    private Pageable createPageable(int page, int size, String sortBy, boolean isAsc) {
+        int validatedSize = List.of(10, 20).contains(size) ? size : 10;
+        int validatedPage = Math.max(page, 0);
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        // 유효한 정렬 필드
+        final List<String> ALLOWED_SORTS = List.of("issueStartAt", "issueEndAt", "validUntil", "createdAt", "discountRate");
+        String validatedSortBy = ALLOWED_SORTS.contains(sortBy) ? sortBy : "createdAt";
+
+        return PageRequest.of(validatedPage, validatedSize, Sort.by(direction, validatedSortBy));
     }
 }

--- a/coupon/src/main/java/com/high/coupon/application/CouponService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponService.java
@@ -2,8 +2,13 @@ package com.high.coupon.application;
 
 import com.high.coupon.application.dto.request.CouponCreateRequest;
 import com.high.coupon.application.dto.response.CouponCreateResponse;
+import com.high.coupon.application.dto.response.CouponDetailResponse;
+import com.high.coupon.application.dto.response.CouponListResponse;
+import com.high.coupon.application.exception.CouponNotFoundException;
 import com.high.coupon.domain.entity.Coupon;
 import com.high.coupon.domain.repository.CouponRepository;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,5 +40,27 @@ public class CouponService {
 
         Coupon savedCoupon = couponRepository.save(coupon);
         return CouponCreateResponse.from(savedCoupon);
+    }
+
+    // 쿠폰 단건 조회
+    public CouponDetailResponse getCouponDetail(UUID couponId) {
+        Coupon coupon = getCouponById(couponId);
+        return CouponDetailResponse.from(coupon);
+    }
+
+    // 쿠폰 리스트 조회
+    public List<CouponListResponse> getAllCoupons() {
+        return couponRepository.findAll()
+                .stream()
+                .map(CouponListResponse::from)
+                .toList();
+    }
+
+    /**
+     * 쿠폰 ID 조회 메서드
+     */
+    public Coupon getCouponById(UUID couponId){
+        return couponRepository.findById(couponId)
+                .orElseThrow(CouponNotFoundException::new);
     }
 }

--- a/coupon/src/main/java/com/high/coupon/application/dto/response/CouponDetailResponse.java
+++ b/coupon/src/main/java/com/high/coupon/application/dto/response/CouponDetailResponse.java
@@ -1,0 +1,39 @@
+package com.high.coupon.application.dto.response;
+
+import com.high.coupon.domain.entity.Coupon;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CouponDetailResponse(
+        UUID couponId,
+        String name,
+        String description,
+        BigDecimal discountRate,
+        Integer totalQuantity,
+        LocalDateTime issueStartAt,
+        LocalDateTime issueEndAt,
+        LocalDateTime validUntil,
+        LocalDateTime createdAt,
+        // todo String -> UUID
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy
+) {
+    public static CouponDetailResponse from(Coupon coupon) {
+        return new CouponDetailResponse(
+                coupon.getId(),
+                coupon.getName(),
+                coupon.getDescription(),
+                coupon.getDiscountRate(),
+                coupon.getTotalQuantity(),
+                coupon.getIssueStartAt(),
+                coupon.getIssueEndAt(),
+                coupon.getValidUntil(),
+                coupon.getCreatedAt(),
+                coupon.getCreatedBy(),
+                coupon.getUpdatedAt(),
+                coupon.getUpdatedBy()
+        );
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/application/dto/response/CouponListResponse.java
+++ b/coupon/src/main/java/com/high/coupon/application/dto/response/CouponListResponse.java
@@ -1,0 +1,30 @@
+package com.high.coupon.application.dto.response;
+
+import com.high.coupon.domain.entity.Coupon;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CouponListResponse(
+        UUID couponId,
+        String name,
+        String description,
+        BigDecimal discountRate,
+        Integer totalQuantity,
+        LocalDateTime issueStartAt,
+        LocalDateTime issueEndAt,
+        LocalDateTime validUntil
+) {
+    public static CouponListResponse from(Coupon coupon) {
+        return new CouponListResponse(
+                coupon.getId(),
+                coupon.getName(),
+                coupon.getDescription(),
+                coupon.getDiscountRate(),
+                coupon.getTotalQuantity(),
+                coupon.getIssueStartAt(),
+                coupon.getIssueEndAt(),
+                coupon.getValidUntil()
+        );
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/application/exception/CouponNotFoundException.java
+++ b/coupon/src/main/java/com/high/coupon/application/exception/CouponNotFoundException.java
@@ -1,0 +1,10 @@
+package com.high.coupon.application.exception;
+
+import com.high.coupon.exception.CouponErrorCode;
+import com.library.module.exception.CustomException;
+
+public class CouponNotFoundException extends CustomException {
+    public CouponNotFoundException(){
+        super(CouponErrorCode.COUPON_NOT_FOUND);
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/high/coupon/domain/repository/CouponRepository.java
@@ -1,13 +1,14 @@
 package com.high.coupon.domain.repository;
 
 import com.high.coupon.domain.entity.Coupon;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CouponRepository {
 
     Coupon save(Coupon coupon);
     Optional<Coupon> findById(UUID id);
-    List<Coupon> findAll();
+    Page<Coupon> findAll(Pageable pageable);
 }

--- a/coupon/src/main/java/com/high/coupon/domain/repository/CouponRepository.java
+++ b/coupon/src/main/java/com/high/coupon/domain/repository/CouponRepository.java
@@ -1,8 +1,13 @@
 package com.high.coupon.domain.repository;
 
 import com.high.coupon.domain.entity.Coupon;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface CouponRepository {
 
     Coupon save(Coupon coupon);
+    Optional<Coupon> findById(UUID id);
+    List<Coupon> findAll();
 }

--- a/coupon/src/main/java/com/high/coupon/exception/CouponErrorCode.java
+++ b/coupon/src/main/java/com/high/coupon/exception/CouponErrorCode.java
@@ -1,10 +1,30 @@
 package com.high.coupon.exception;
 
-public enum CouponErrorCode {
+import com.library.module.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
-    // todo 작성 필요
+@Getter
+@RequiredArgsConstructor
+public enum CouponErrorCode implements BaseErrorCode {
+
+    /**
+     * COUPON - error 6000번대
+     */
 
     // application
+    COUPON_NOT_FOUND(4000, HttpStatus.NOT_FOUND, "쿠폰을 찾을 수 없습니다."),
+
 
     // domain
+
+
+
+    ;
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+
 }

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponRepositoryAdaptor.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponRepositoryAdaptor.java
@@ -2,10 +2,11 @@ package com.high.coupon.infrastructure.persistence;
 
 import com.high.coupon.domain.entity.Coupon;
 import com.high.coupon.domain.repository.CouponRepository;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -25,8 +26,7 @@ public class CouponRepositoryAdaptor implements CouponRepository {
     }
 
     @Override
-    public List<Coupon> findAll(){
-        return jpaCouponRepository.findAll();
+    public Page<Coupon> findAll(Pageable pageable) {
+        return jpaCouponRepository.findAll(pageable);
     }
-
 }

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponRepositoryAdaptor.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponRepositoryAdaptor.java
@@ -2,6 +2,9 @@ package com.high.coupon.infrastructure.persistence;
 
 import com.high.coupon.domain.entity.Coupon;
 import com.high.coupon.domain.repository.CouponRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,6 +17,16 @@ public class CouponRepositoryAdaptor implements CouponRepository {
     @Override
     public Coupon save(Coupon coupon){
         return jpaCouponRepository.save(coupon);
+    }
+
+    @Override
+    public Optional<Coupon> findById(UUID id){
+        return jpaCouponRepository.findById(id);
+    }
+
+    @Override
+    public List<Coupon> findAll(){
+        return jpaCouponRepository.findAll();
     }
 
 }

--- a/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
@@ -5,9 +5,9 @@ import com.high.coupon.application.dto.request.CouponCreateRequest;
 import com.high.coupon.application.dto.response.CouponCreateResponse;
 import com.high.coupon.application.dto.response.CouponDetailResponse;
 import com.high.coupon.application.dto.response.CouponListResponse;
+import com.library.jpa.response.PageResponse;
 import com.library.module.response.ApiResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,9 +46,20 @@ public class CouponController {
     }
 
     // 발행 쿠폰 리스트 조회 (관리자)
+    /**
+     * 생성 쿠폰 리스트 (관리자용) default 10 & 20 paging
+     * @param sortBy 정렬 필드 (issueStartAt, validUntil, createdAt, discountRate)
+     * @param isAsc 오름차순/내림차순 default createdAt DESC
+     * @return 페이징 된 리스트
+     */
     @GetMapping
-    public ResponseEntity<ApiResponse<List<CouponListResponse>>> getAllCoupons() {
-        var responseList = couponService.getAllCoupons();
-        return ResponseEntity.ok(ApiResponse.success(responseList));
+    public ResponseEntity<ApiResponse<PageResponse<CouponListResponse>>> getCouponPage(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "false") boolean isAsc
+    ) {
+        var response = couponService.getCouponPage(page, size, sortBy, isAsc);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
+++ b/coupon/src/main/java/com/high/coupon/presentation/CouponController.java
@@ -3,11 +3,17 @@ package com.high.coupon.presentation;
 import com.high.coupon.application.CouponService;
 import com.high.coupon.application.dto.request.CouponCreateRequest;
 import com.high.coupon.application.dto.response.CouponCreateResponse;
+import com.high.coupon.application.dto.response.CouponDetailResponse;
+import com.high.coupon.application.dto.response.CouponListResponse;
 import com.library.module.response.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +34,20 @@ public class CouponController {
             @RequestBody @Valid CouponCreateRequest request){
         var response = couponService.createCoupon(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    // 발행 쿠폰 상세 조회 (관리자)
+    @GetMapping("/{couponId}")
+    public ResponseEntity<ApiResponse<CouponDetailResponse>> getCouponById(
+            @PathVariable("couponId") UUID couponId) {
+        var response = couponService.getCouponDetail(couponId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 발행 쿠폰 리스트 조회 (관리자)
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CouponListResponse>>> getAllCoupons() {
+        var responseList = couponService.getAllCoupons();
+        return ResponseEntity.ok(ApiResponse.success(responseList));
     }
 }


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #8 

## 📝 Description
- 공통 모듈 버전 변경
- 관리자용 쿠폰 조회 api(단건, 리스트) 구현 (생성한 쿠폰 조회)
- 페이징 시 ALLOWED_SORTS 사용으로 유효하지 않은 값은 기본 값(createdAt) 대체로 DB 보호
- common-jpa 모듈 첫번째 페이징 응답 사용


| 쿠폰 페이징 정렬 기준        | 설명                                           |
|------------------|------------------------------------------------|
| `issueStartAt`   | 발행 시작일 기준 |
| `issueEndAt`     | 발행 종료일 기준 |
| `validUntil`     | 쿠폰 유효기간 기준  |
| `createdAt`      | 생성일 기준  |
| `discountRate`   | 할인율 기준  |

**✅ 쿠폰 페이징 사이즈 10, 20 유효**

## 🌐 Test Result

- **리스트 조회**
<img width="1048" height="865" alt="스크린샷 2025-12-02 145106" src="https://github.com/user-attachments/assets/9b772d87-a69d-41a7-b4e9-08912161b1d7" />

---

- **단건 조회**
<img width="912" height="876" alt="스크린샷 2025-12-02 131141" src="https://github.com/user-attachments/assets/f2738f8c-51bc-43e2-acb6-ed54b9384984" />

---

- **에러 응답 확인**
<img width="985" height="697" alt="스크린샷 2025-12-02 131550" src="https://github.com/user-attachments/assets/79f93ba5-20c4-423d-adb8-8529ced66070" />


## 🔎 To Reviewer
- 도메인 예외는 다음 기능 구현 때 같이 리팩토링해서 올리겠습니다 🤛🏻
- 페이징을 저 한 곳에서만 사용하긴 하는데, 서비스 모듈 내에서 util로 따로 빼볼까 고민중입니다 🤔


