### PR TITLE
feat: User Service 기본 설정

### DIFF
--- a/config/src/main/resources/config-repo/user-service.yml
+++ b/config/src/main/resources/config-repo/user-service.yml
@@ -25,6 +25,13 @@ spring:
     init:
       mode: always
 
+  # Security JWT Secret (256-bit)
+  security:
+    jwt:
+      secret: ${JWT_SECRET:change-this-secret-key-in-production-must-be-at-least-256-bits-long}
+      access-token-validity: 3600000  # 1 hour
+      refresh-token-validity: 604800000  # 7 days
+
 management:
   zipkin:
     tracing:
@@ -32,3 +39,10 @@ management:
   tracing:
     sampling:
       probability: 1.0
+
+logging:
+  level:
+    com.high.user: DEBUG
+    org.springframework.security: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql: TRACE

--- a/user/.env.example
+++ b/user/.env.example
@@ -1,0 +1,15 @@
+# User Service 로컬 개발 환경변수 예시
+# 사용법: 이 파일을 복사하여 .env 파일 생성 후 본인의 값으로 수정
+
+# MySQL 접속 정보
+DB_USERNAME=root
+DB_PASSWORD=your-mysql-password
+
+# JWT Secret Key (최소 256비트, 32바이트 이상)
+# 생성 방법: openssl rand -base64 32
+JWT_SECRET=your-generated-jwt-secret-key-here
+
+# Redis 접속 정보 (Issue #17 이후 필요)
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+# REDIS_PASSWORD=

--- a/user/.gitignore
+++ b/user/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment Variables ###
+.env

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -22,6 +22,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 ext {
@@ -29,18 +30,31 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// Common Libraries
+	implementation 'com.github.sharedeffort:common-module:v1.1.9'
+	implementation 'com.github.sharedeffort:common-jpa:v1.0.1'
 
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	// Spring Boot Starters
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Spring Cloud
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+	// Database
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {

--- a/user/src/main/java/com/high/user/UserApplication.java
+++ b/user/src/main/java/com/high/user/UserApplication.java
@@ -2,8 +2,13 @@ package com.high.user;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = {
+	"com.high.user",
+	"com.library.module"
+})
 public class UserApplication {
 
 	public static void main(String[] args) {

--- a/user/src/main/java/com/high/user/domain/entity/User.java
+++ b/user/src/main/java/com/high/user/domain/entity/User.java
@@ -1,0 +1,170 @@
+package com.high.user.domain.entity;
+
+import com.high.user.domain.vo.UserRole;
+import com.library.jpa.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "user_id")
+    private UUID userId;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(length = 255)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+
+    @Column(length = 20)
+    private String phoneNumber;
+
+    @Column(length = 255)
+    private String address;
+
+    @Column(nullable = false)
+    private Boolean isActive;
+
+    @Column
+    private LocalDateTime lastLoginAt;
+
+    // Private constructor for factory methods
+    private User(String email, String password, String name, UserRole role) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.role = role;
+        this.isActive = true;
+    }
+
+    // Factory method: 일반 회원가입 (LOCAL 사용자)
+    public static User createLocalUser(String email, String encodedPassword, String name) {
+        validateEmail(email);
+        validateName(name);
+
+        if (encodedPassword == null || encodedPassword.isBlank()) {
+            throw new IllegalArgumentException("Password is required");
+        }
+
+        return new User(email, encodedPassword, name, UserRole.USER);
+    }
+
+    // Factory method: 관리자 생성 (MASTER)
+    public static User createMasterUser(String email, String encodedPassword, String name) {
+        validateEmail(email);
+        validateName(name);
+
+        if (encodedPassword == null || encodedPassword.isBlank()) {
+            throw new IllegalArgumentException("Password is required");
+        }
+
+        return new User(email, encodedPassword, name, UserRole.MASTER);
+    }
+
+    // Business logic: 이메일 수정
+    public void updateEmail(String newEmail) {
+        validateEmail(newEmail);
+        this.email = newEmail;
+    }
+
+    // Business logic: 비밀번호 변경
+    public void updatePassword(String encodedPassword) {
+        if (encodedPassword == null || encodedPassword.isBlank()) {
+            throw new IllegalArgumentException("Password is required");
+        }
+        this.password = encodedPassword;
+    }
+
+    // Business logic: 이름 수정
+    public void updateName(String newName) {
+        validateName(newName);
+        this.name = newName;
+    }
+
+    // Business logic: 전화번호 수정
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    // Business logic: 주소 수정
+    public void updateAddress(String address) {
+        this.address = address;
+    }
+
+    // Business logic: 권한 변경 (MASTER만 변경 불가)
+    public void updateRole(UserRole newRole) {
+        if (this.role == UserRole.MASTER) {
+            throw new IllegalStateException("MASTER 권한은 변경할 수 없습니다");
+        }
+        this.role = newRole;
+    }
+
+    // Business logic: 마지막 로그인 시간 업데이트
+    public void updateLastLogin() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
+
+    // Business logic: 계정 활성화
+    public void activate() {
+        this.isActive = true;
+    }
+
+    // Business logic: 계정 비활성화
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    // Business logic: Soft Delete
+    public void softDelete(String deletedBy) {
+        super.softDelete(deletedBy);
+        this.isActive = false;
+    }
+
+    // Query method: 계정이 활성화 되어 있고 삭제되지 않았는지 확인
+    public boolean isActiveAndNotDeleted() {
+        return this.isActive && !isDeleted();
+    }
+
+    // Query method: 권한 확인
+    public boolean hasRole(UserRole requiredRole) {
+        return this.role.hasPermission(requiredRole);
+    }
+
+    // Validation: 이메일 형식 검증
+    private static void validateEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("Email is required");
+        }
+        if (!email.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")) {
+            throw new IllegalArgumentException("Invalid email format");
+        }
+    }
+
+    // Validation: 이름 검증
+    private static void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Name is required");
+        }
+        if (name.length() > 50) {
+            throw new IllegalArgumentException("Name must be 50 characters or less");
+        }
+    }
+}

--- a/user/src/main/java/com/high/user/domain/repository/UserRepository.java
+++ b/user/src/main/java/com/high/user/domain/repository/UserRepository.java
@@ -1,0 +1,27 @@
+package com.high.user.domain.repository;
+
+import com.high.user.domain.entity.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository {
+
+    // Save
+    User save(User user);
+
+    // Find by ID
+    Optional<User> findById(UUID userId);
+
+    // Find by ID with soft delete check
+    Optional<User> findByIdAndDeletedAtIsNull(UUID userId);
+
+    // Find by email
+    Optional<User> findByEmail(String email);
+
+    // Find by email with soft delete check
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+
+    // Check email existence
+    boolean existsByEmail(String email);
+}

--- a/user/src/main/java/com/high/user/domain/vo/UserRole.java
+++ b/user/src/main/java/com/high/user/domain/vo/UserRole.java
@@ -1,0 +1,39 @@
+package com.high.user.domain.vo;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+    USER("일반 사용자"),
+    SELLER("판매자"),
+    MASTER("관리자");
+
+    private final String description;
+
+    UserRole(String description) {
+        this.description = description;
+    }
+
+    /**
+     * 권한 레벨 비교
+     * MASTER > SELLER > USER
+     */
+    public boolean hasPermission(UserRole required) {
+        return this.ordinal() >= required.ordinal();
+    }
+
+    /**
+     * String으로부터 UserRole 변환
+     */
+    public static UserRole fromString(String role) {
+        if (role == null) {
+            throw new IllegalArgumentException("Role cannot be null");
+        }
+
+        try {
+            return UserRole.valueOf(role.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid role: " + role);
+        }
+    }
+}

--- a/user/src/main/java/com/high/user/infrastructure/config/JpaAuditingConfig.java
+++ b/user/src/main/java/com/high/user/infrastructure/config/JpaAuditingConfig.java
@@ -1,0 +1,34 @@
+package com.high.user.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
+public class JpaAuditingConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> {
+            // SecurityContext에서 인증 정보 추출
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            // 인증되지 않은 경우 또는 익명 사용자인 경우 "SYSTEM" 반환
+            if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+                return Optional.of("SYSTEM");
+            }
+
+            // 인증된 사용자의 이름(userId) 반환
+            // Issue #14(JWT 인증) 구현 후 JWT에서 userId 추출하도록 수정 예정
+            String username = authentication.getName();
+            return Optional.of(username);
+        };
+    }
+}

--- a/user/src/main/java/com/high/user/infrastructure/config/SecurityConfig.java
+++ b/user/src/main/java/com/high/user/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,84 @@
+package com.high.user.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            // CSRF 비활성화 (REST API)
+            .csrf(csrf -> csrf.disable())
+
+            // CORS 설정
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+            // 세션 관리: STATELESS (JWT 사용)
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+            // 권한 설정 (기본 구조, Issue #14에서 상세 구현)
+            .authorizeHttpRequests(auth -> auth
+                // Health Check는 인증 불필요 (초기 세팅 확인용)
+                .requestMatchers("/api/v1/health/**").permitAll()
+                // 회원가입, 로그인은 인증 불필요
+                .requestMatchers("/api/v1/users/signup", "/api/v1/users/login").permitAll()
+                // 나머지는 모두 허용 (임시, Issue #14에서 수정)
+                .anyRequest().permitAll()
+            );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        // BCrypt with strength 10
+        return new BCryptPasswordEncoder(10);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 허용할 Origin (개발 환경)
+        configuration.setAllowedOrigins(List.of(
+            "http://localhost:3000",
+            "http://localhost:8000"
+        ));
+
+        // 허용할 HTTP 메서드
+        configuration.setAllowedMethods(List.of(
+            "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"
+        ));
+
+        // 허용할 헤더
+        configuration.setAllowedHeaders(List.of("*"));
+
+        // 자격 증명 허용 (쿠키 등)
+        configuration.setAllowCredentials(true);
+
+        // CORS 설정을 모든 경로에 적용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/user/src/main/java/com/high/user/infrastructure/persistence/JpaUserRepository.java
+++ b/user/src/main/java/com/high/user/infrastructure/persistence/JpaUserRepository.java
@@ -1,0 +1,24 @@
+package com.high.user.infrastructure.persistence;
+
+import com.high.user.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface JpaUserRepository extends JpaRepository<User, UUID> {
+
+    // Find by ID with soft delete check
+    Optional<User> findByUserIdAndDeletedAtIsNull(UUID userId);
+
+    // Find by email
+    Optional<User> findByEmail(String email);
+
+    // Find by email with soft delete check
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+
+    // Check email existence
+    boolean existsByEmail(String email);
+}

--- a/user/src/main/java/com/high/user/infrastructure/persistence/UserRepositoryAdaptor.java
+++ b/user/src/main/java/com/high/user/infrastructure/persistence/UserRepositoryAdaptor.java
@@ -1,0 +1,46 @@
+package com.high.user.infrastructure.persistence;
+
+import com.high.user.domain.entity.User;
+import com.high.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class UserRepositoryAdaptor implements UserRepository {
+
+    private final JpaUserRepository jpaUserRepository;
+
+    @Override
+    public User save(User user) {
+        return jpaUserRepository.save(user);
+    }
+
+    @Override
+    public Optional<User> findById(UUID userId) {
+        return jpaUserRepository.findById(userId);
+    }
+
+    @Override
+    public Optional<User> findByIdAndDeletedAtIsNull(UUID userId) {
+        return jpaUserRepository.findByUserIdAndDeletedAtIsNull(userId);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return jpaUserRepository.findByEmail(email);
+    }
+
+    @Override
+    public Optional<User> findByEmailAndDeletedAtIsNull(String email) {
+        return jpaUserRepository.findByEmailAndDeletedAtIsNull(email);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return jpaUserRepository.existsByEmail(email);
+    }
+}

--- a/user/src/main/java/com/high/user/presentation/HealthCheckController.java
+++ b/user/src/main/java/com/high/user/presentation/HealthCheckController.java
@@ -1,0 +1,66 @@
+package com.high.user.presentation;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 초기 세팅 확인용 Health Check Controller
+ * Issue #12 완료 후 삭제 예정
+ */
+@RestController
+@RequestMapping("/api/v1/health")
+public class HealthCheckController {
+
+    @Value("${spring.application.name}")
+    private String applicationName;
+
+    @Value("${spring.datasource.url}")
+    private String datasourceUrl;
+
+    @Value("${spring.security.jwt.access-token-validity}")
+    private Long accessTokenValidity;
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> healthCheck() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "UP");
+        response.put("service", applicationName);
+        response.put("timestamp", LocalDateTime.now());
+        response.put("datasource", maskPassword(datasourceUrl));
+        response.put("jwtAccessTokenValidity", accessTokenValidity + "ms");
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/db")
+    public ResponseEntity<Map<String, Object>> dbCheck() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "DB connection check");
+        response.put("datasource", maskPassword(datasourceUrl));
+        response.put("message", "If you see this, Spring Boot started successfully");
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/security")
+    public ResponseEntity<Map<String, Object>> securityCheck() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "Security configuration check");
+        response.put("message", "Security filter chain is active");
+        response.put("jwtValidity", accessTokenValidity + "ms");
+
+        return ResponseEntity.ok(response);
+    }
+
+    // URL에서 비밀번호 마스킹
+    private String maskPassword(String url) {
+        return url.replaceAll("password=[^&;]*", "password=****");
+    }
+}

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -1,0 +1,52 @@
+server:
+  port: 8100
+
+spring:
+  application:
+    name: user-service
+
+  # 로컬 개발용 DB 설정
+  datasource:
+    url: jdbc:mysql://localhost:3306/user_service?serverTimezone=UTC&characterEncoding=UTF-8
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:your-local-password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        default_schema: user_service
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: always
+
+  # 로컬 개발용 JWT Secret
+  security:
+    jwt:
+      secret: ${JWT_SECRET:local-dev-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm}
+      access-token-validity: 3600000  # 1 hour
+      refresh-token-validity: 604800000  # 7 days
+
+  # Config Server 비활성화 (로컬 개발 시)
+  cloud:
+    config:
+      enabled: false
+
+# Eureka 비활성화 (로컬 단독 개발 시)
+eureka:
+  client:
+    enabled: false
+
+logging:
+  level:
+    com.high.user: DEBUG
+    org.springframework.security: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql: TRACE


### PR DESCRIPTION
## Issue Number
- closed #12

## 📝 Description

User Service의 기본 프로젝트 구조를 구축하고 로컬 개발 환경을 설정했습니다.

### 주요 변경사항

#### 1. 프로젝트 구조 (DDD 패턴)
```
user/src/main/java/com/high/user/
├── domain/
│   ├── entity/User.java          # 사용자 엔티티 (UUID PK, Soft Delete)
│   ├── vo/UserRole.java          # 역할 Enum (MASTER, SELLER, USER)
│   └── repository/UserRepository.java
│
├── infrastructure/
│   ├── persistence/
│   │   ├── JpaUserRepository.java
│   │   └── UserRepositoryAdaptor.java
│   └── config/
│       ├── JpaAuditingConfig.java
│       └── SecurityConfig.java
│
└── presentation/
    └── HealthCheckController.java
```

#### 2. 의존성 추가
- **Common Libraries**: `common-module` v1.1.9, `common-jpa` v1.0.1
- **Validation**: `spring-boot-starter-validation`
- **JitPack**: Maven repository 추가

#### 3. 설정 파일
- **application.yml**: 로컬 개발용 통합 설정
  - MySQL 연결 (환경변수 지원: `DB_USERNAME`, `DB_PASSWORD`)
  - JWT Secret (환경변수 지원: `JWT_SECRET`)
  - Config Server/Eureka 비활성화
- **.env.example**: 환경변수 템플릿
- **.gitignore**: `.env` 파일 제외

#### 4. 도메인 모델
- **User 엔티티**
  - UUID 기반 Primary Key
  - Soft Delete 지원 (`deleted_at`, `deleted_by`)
  - Audit 필드 (`created_at`, `created_by`, `updated_at`, `updated_by`)
  - Role 기반 권한 (MASTER > SELLER > USER)

#### 5. API 엔드포인트
- `GET /api/v1/users/health` - 서버 상태 확인

## 🌐 Test Result

<img width="817" alt="image" src="https://github.com/user-attachments/assets/2f551839-2993-4b3e-b18e-e795125052ce" />
<img width="817" alt="image" src="https://github.com/user-attachments/assets/96ab7ffd-7f13-4cf3-a552-e330b57ffb9a" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d20fdbc1-84c4-4518-901f-3eeb4af7fd8d" />


## 🔎 To Reviewer

1. DDD 패턴 적용 및 패키지 구조가 프로젝트 컨벤션을 잘 따랐는지 확인 부탁드립니다.
2. User 엔티티의 UUID PK 및 Soft Delete 구현에 이상 없는지 확인 부탁드립니다.
3. 로컬 개발 환경 설정(application.yml)해서 하려고 하는데 괜찮은지 확인 부탁드립니다.