### PR TITLE
feat: User Service JWT 인증 구현

### DIFF
--- a/user/build.gradle
+++ b/user/build.gradle
@@ -47,6 +47,14 @@ dependencies {
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/user/src/main/java/com/high/user/application/dto/response/TokenResponse.java
+++ b/user/src/main/java/com/high/user/application/dto/response/TokenResponse.java
@@ -1,0 +1,21 @@
+package com.high.user.application.dto.response;
+
+/**
+ * JWT 토큰 응답 DTO
+ * AccessToken과 RefreshToken을 클라이언트에게 반환
+ */
+public record TokenResponse(
+    String accessToken,
+    String refreshToken,
+    String tokenType,
+    Long expiresIn  // 초 단위 (예: 3600 = 1시간)
+) {
+    public static TokenResponse of(String accessToken, String refreshToken, Long expiresIn) {
+        return new TokenResponse(
+            accessToken,
+            refreshToken,
+            "Bearer",
+            expiresIn
+        );
+    }
+}

--- a/user/src/main/java/com/high/user/application/service/RefreshTokenService.java
+++ b/user/src/main/java/com/high/user/application/service/RefreshTokenService.java
@@ -1,0 +1,88 @@
+package com.high.user.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Refresh Token Redis 저장/조회/삭제 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${spring.security.jwt.refresh-token-validity}")
+    private Long refreshTokenValidity;
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+
+    /**
+     * Refresh Token을 Redis에 저장
+     * @param userId 사용자 ID
+     * @param refreshToken Refresh Token
+     */
+    public void saveRefreshToken(UUID userId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + userId.toString();
+
+        redisTemplate.opsForValue().set(
+            key,
+            refreshToken,
+            refreshTokenValidity,
+            TimeUnit.MILLISECONDS
+        );
+
+        log.debug("Refresh token saved for user: {}", userId);
+    }
+
+    /**
+     * Redis에서 Refresh Token 조회
+     * @param userId 사용자 ID
+     * @return Refresh Token (없으면 null)
+     */
+    public String getRefreshToken(UUID userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId.toString();
+        String token = redisTemplate.opsForValue().get(key);
+
+        log.debug("Refresh token retrieved for user: {}, exists: {}", userId, token != null);
+        return token;
+    }
+
+    /**
+     * Redis에서 Refresh Token 삭제 (로그아웃 시 사용)
+     * @param userId 사용자 ID
+     */
+    public void deleteRefreshToken(UUID userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId.toString();
+        Boolean deleted = redisTemplate.delete(key);
+
+        log.debug("Refresh token deleted for user: {}, success: {}", userId, deleted);
+    }
+
+    /**
+     * Refresh Token 검증 (저장된 토큰과 일치하는지 확인)
+     * @param userId 사용자 ID
+     * @param refreshToken 검증할 Refresh Token
+     * @return 일치 여부
+     */
+    public boolean validateRefreshToken(UUID userId, String refreshToken) {
+        String storedToken = getRefreshToken(userId);
+
+        if (storedToken == null) {
+            log.warn("No refresh token found for user: {}", userId);
+            return false;
+        }
+
+        boolean isValid = storedToken.equals(refreshToken);
+        log.debug("Refresh token validation for user: {}, valid: {}", userId, isValid);
+
+        return isValid;
+    }
+}

--- a/user/src/main/java/com/high/user/infrastructure/config/RedisConfig.java
+++ b/user/src/main/java/com/high/user/infrastructure/config/RedisConfig.java
@@ -1,0 +1,56 @@
+package com.high.user.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Redis 설정 클래스
+ * Refresh Token 저장을 위한 RedisTemplate 설정
+ */
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host:localhost}")
+    private String host;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int port;
+
+    /**
+     * Redis 연결 팩토리 설정
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+        return new LettuceConnectionFactory(config);
+    }
+
+    /**
+     * RedisTemplate 설정
+     * String-String 타입으로 설정
+     */
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        // Key-Value 모두 String Serializer 사용
+        StringRedisSerializer serializer = new StringRedisSerializer();
+        template.setKeySerializer(serializer);
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(serializer);
+        template.setHashValueSerializer(serializer);
+
+        return template;
+    }
+}

--- a/user/src/main/java/com/high/user/infrastructure/config/SecurityConfig.java
+++ b/user/src/main/java/com/high/user/infrastructure/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.high.user.infrastructure.config;
 
+import com.high.user.infrastructure.security.CustomAccessDeniedHandler;
+import com.high.user.infrastructure.security.JwtAuthenticationEntryPoint;
+import com.high.user.infrastructure.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +13,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -21,6 +25,10 @@ import java.util.List;
 @EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -35,15 +43,26 @@ public class SecurityConfig {
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-            // 권한 설정 (기본 구조, Issue #14에서 상세 구현)
+            // 권한 설정
             .authorizeHttpRequests(auth -> auth
-                // Health Check는 인증 불필요 (초기 세팅 확인용)
+                // Health Check는 인증 불필요
                 .requestMatchers("/api/v1/health/**").permitAll()
-                // 회원가입, 로그인은 인증 불필요
-                .requestMatchers("/api/v1/users/signup", "/api/v1/users/login").permitAll()
-                // 나머지는 모두 허용 (임시, Issue #14에서 수정)
-                .anyRequest().permitAll()
-            );
+                // 회원가입, 로그인, 토큰 재발급은 인증 불필요
+                .requestMatchers("/api/v1/users/signup", "/api/v1/users/login", "/api/v1/users/reissue").permitAll()
+                // MASTER 전용 API
+                .requestMatchers("/api/v1/users/admin/**").hasRole("MASTER")
+                // 나머지는 모두 인증 필요
+                .anyRequest().authenticated()
+            )
+
+            // 예외 처리 핸들러 설정
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)  // 401 Unauthorized
+                .accessDeniedHandler(customAccessDeniedHandler)         // 403 Forbidden
+            )
+
+            // JWT 필터 추가 (UsernamePasswordAuthenticationFilter 이전에 실행)
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/user/src/main/java/com/high/user/infrastructure/security/CustomAccessDeniedHandler.java
+++ b/user/src/main/java/com/high/user/infrastructure/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,50 @@
+package com.high.user.infrastructure.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 권한 부족 시 처리하는 Handler (403 Forbidden)
+ * 인증은 되었으나 해당 리소스에 대한 권한이 없을 때 동작
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+
+        log.error("Access denied error: {}", accessDeniedException.getMessage());
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("success", false);
+        errorResponse.put("code", 1007);
+        errorResponse.put("message", "접근 권한이 없습니다.");
+        errorResponse.put("path", request.getRequestURI());
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/user/src/main/java/com/high/user/infrastructure/security/JwtAuthenticationEntryPoint.java
+++ b/user/src/main/java/com/high/user/infrastructure/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,50 @@
+package com.high.user.infrastructure.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 인증 실패 시 처리하는 EntryPoint (401 Unauthorized)
+ * 유효하지 않은 JWT 토큰으로 접근 시 동작
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+
+        log.error("Unauthorized error: {}", authException.getMessage());
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("success", false);
+        errorResponse.put("code", 1003);
+        errorResponse.put("message", "인증이 필요합니다. 유효한 토큰을 제공해주세요.");
+        errorResponse.put("path", request.getRequestURI());
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/user/src/main/java/com/high/user/infrastructure/security/JwtAuthenticationFilter.java
+++ b/user/src/main/java/com/high/user/infrastructure/security/JwtAuthenticationFilter.java
@@ -1,0 +1,92 @@
+package com.high.user.infrastructure.security;
+
+import com.high.user.domain.vo.UserRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+
+/**
+ * JWT 인증 필터
+ * Authorization 헤더에서 Bearer 토큰을 추출하여 검증하고 SecurityContext에 인증 정보 설정
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        try {
+            // 1. Authorization 헤더에서 JWT 토큰 추출
+            String jwt = extractJwtFromRequest(request);
+
+            // 2. 토큰이 존재하고 유효한 경우
+            if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+
+                // 3. 토큰에서 사용자 정보 추출
+                UUID userId = jwtTokenProvider.getUserIdFromToken(jwt);
+                UserRole role = jwtTokenProvider.getRoleFromToken(jwt);
+
+                // 4. Spring Security Authentication 객체 생성
+                UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                        userId,  // Principal
+                        null,    // Credentials (비밀번호 불필요)
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()))
+                    );
+
+                // 5. Request 정보 설정
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                // 6. SecurityContext에 인증 정보 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.debug("JWT authentication successful for user: {}, role: {}", userId, role);
+            }
+        } catch (Exception e) {
+            log.error("Could not set user authentication in security context", e);
+        }
+
+        // 7. 다음 필터로 진행
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰 추출
+     * @param request HTTP 요청
+     * @return JWT 토큰 (없으면 null)
+     */
+    private String extractJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/user/src/main/java/com/high/user/infrastructure/security/JwtTokenProvider.java
+++ b/user/src/main/java/com/high/user/infrastructure/security/JwtTokenProvider.java
@@ -1,0 +1,168 @@
+package com.high.user.infrastructure.security;
+
+import com.high.user.domain.vo.UserRole;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * JWT 토큰 생성 및 검증을 담당하는 Provider
+ * JJWT 0.12.x 사용
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${spring.security.jwt.secret}")
+    private String secretKeyString;
+
+    @Value("${spring.security.jwt.access-token-validity}")
+    private Long accessTokenValidity;
+
+    @Value("${spring.security.jwt.refresh-token-validity}")
+    private Long refreshTokenValidity;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    protected void init() {
+        // Secret Key를 바이트 배열로 변환 후 SecretKey 객체 생성
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
+        log.info("JwtTokenProvider initialized with key length: {} bytes",
+                 secretKeyString.getBytes(StandardCharsets.UTF_8).length);
+    }
+
+    /**
+     * Access Token 생성
+     * @param userId 사용자 ID
+     * @param role 사용자 권한
+     * @return JWT Access Token
+     */
+    public String createAccessToken(UUID userId, UserRole role) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + accessTokenValidity);
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("role", role.name())
+                .claim("type", "access")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    /**
+     * Refresh Token 생성
+     * @param userId 사용자 ID
+     * @return JWT Refresh Token
+     */
+    public String createRefreshToken(UUID userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + refreshTokenValidity);
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("type", "refresh")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    /**
+     * 토큰에서 사용자 ID 추출
+     * @param token JWT 토큰
+     * @return 사용자 ID (UUID)
+     */
+    public UUID getUserIdFromToken(String token) {
+        Claims claims = parseClaims(token);
+        String userIdString = claims.getSubject();
+        return UUID.fromString(userIdString);
+    }
+
+    /**
+     * 토큰에서 권한 추출
+     * @param token JWT 토큰
+     * @return 사용자 권한
+     */
+    public UserRole getRoleFromToken(String token) {
+        Claims claims = parseClaims(token);
+        String roleString = claims.get("role", String.class);
+        return UserRole.valueOf(roleString);
+    }
+
+    /**
+     * 토큰 검증
+     * @param token JWT 토큰
+     * @return 유효성 여부
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * 토큰이 만료되었는지 확인
+     * @param token JWT 토큰
+     * @return 만료 여부
+     */
+    public boolean isTokenExpired(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            return claims.getExpiration().before(new Date());
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+    }
+
+    /**
+     * Access Token 유효기간 반환 (초 단위)
+     * @return 유효기간 (초)
+     */
+    public Long getAccessTokenValidityInSeconds() {
+        return accessTokenValidity / 1000;
+    }
+
+    /**
+     * Claims 파싱 (만료된 토큰도 파싱 가능)
+     * @param token JWT 토큰
+     * @return Claims 객체
+     */
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰도 Claims는 반환
+            return e.getClaims();
+        }
+    }
+}

--- a/user/src/main/java/com/high/user/presentation/HealthCheckController.java
+++ b/user/src/main/java/com/high/user/presentation/HealthCheckController.java
@@ -1,6 +1,8 @@
 package com.high.user.presentation;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,11 +14,14 @@ import java.util.Map;
 
 /**
  * 초기 세팅 확인용 Health Check Controller
- * Issue #12 완료 후 삭제 예정
+ * Issue #14 완료 후 삭제 예정
  */
 @RestController
 @RequestMapping("/api/v1/health")
+@RequiredArgsConstructor
 public class HealthCheckController {
+
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${spring.application.name}")
     private String applicationName;
@@ -26,6 +31,12 @@ public class HealthCheckController {
 
     @Value("${spring.security.jwt.access-token-validity}")
     private Long accessTokenValidity;
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
 
     @GetMapping
     public ResponseEntity<Map<String, Object>> healthCheck() {
@@ -55,6 +66,40 @@ public class HealthCheckController {
         response.put("status", "Security configuration check");
         response.put("message", "Security filter chain is active");
         response.put("jwtValidity", accessTokenValidity + "ms");
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/redis")
+    public ResponseEntity<Map<String, Object>> redisCheck() {
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            // Redis 연결 테스트: PING 명령어 실행
+            String pingResult = redisTemplate.getConnectionFactory()
+                .getConnection()
+                .ping();
+
+            // 테스트 데이터 저장 및 조회
+            String testKey = "health_check_test";
+            String testValue = "Redis is working!";
+            redisTemplate.opsForValue().set(testKey, testValue);
+            String retrievedValue = redisTemplate.opsForValue().get(testKey);
+            redisTemplate.delete(testKey);
+
+            response.put("status", "UP");
+            response.put("redis", redisHost + ":" + redisPort);
+            response.put("ping", pingResult);
+            response.put("test", "Set and Get operation successful");
+            response.put("testValue", retrievedValue);
+            response.put("message", "Redis connection is healthy");
+
+        } catch (Exception e) {
+            response.put("status", "DOWN");
+            response.put("redis", redisHost + ":" + redisPort);
+            response.put("error", e.getMessage());
+            response.put("message", "Redis connection failed. Please check if Redis server is running.");
+        }
 
         return ResponseEntity.ok(response);
     }

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -27,6 +27,12 @@ spring:
     init:
       mode: always
 
+  # Redis 설정
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   # 로컬 개발용 JWT Secret
   security:
     jwt:


### PR DESCRIPTION
## Issue Number
- Closes #14

## 📝 Description

JWT 토큰 기반 인증 시스템을 구현했습니다.

**구현 내용:**
- JWT Access Token (1시간) / Refresh Token (7일) 생성 및 검증
- Redis를 활용한 Refresh Token 저장 (TTL 7일)
- JWT 인증 Filter 및 예외 처리 (401 Unauthorized, 403 Forbidden)
- SecurityFilterChain에 JWT Filter 통합

**주요 파일:**
```
application/
├── dto/response/TokenResponse.java       # JWT 응답 DTO
└── service/RefreshTokenService.java      # Refresh Token Redis 관리

infrastructure/
├── config/RedisConfig.java               # Redis 설정
└── security/
    ├── JwtTokenProvider.java             # JWT 생성/검증
    ├── JwtAuthenticationFilter.java      # JWT 인증 필터
    ├── JwtAuthenticationEntryPoint.java  # 401 처리
    └── CustomAccessDeniedHandler.java    # 403 처리
```

**권한 설정:**
- `/api/v1/users/signup`, `/api/v1/users/login` - 인증 불필요
- `/api/v1/users/admin/**` - MASTER 권한 필요
- 나머지 - 인증 필요

## 🌐 Test Result

<img width="656" height="542" alt="image" src="https://github.com/user-attachments/assets/73a79860-f49c-47a9-93c3-c406f14b796a" />

## 🔎 To Reviewer

1. **JwtAuthenticationFilter 구현 패턴** - `OncePerRequestFilter`를 상속하여 토큰 검증 실패 시에도 다음 필터로 진행하도록 구현했습니다. 예외 발생 시 `AuthenticationEntryPoint`가 처리하는 구조가 적절한가요?
2. **Refresh Token 저장 로직** - Redis에 `refresh_token:{userId}` 형식으로 저장하고 TTL을 7일로 설정했습니다. 로그아웃 시 `deleteRefreshToken()`으로 즉시 삭제하는 방식이 보안상 충분한가요, 아니면 Access Token도 블랙리스트 관리가 필요한가요?
