### PR TITLE
fix: User Service 주소 필드 개선 및 Auditing 로직 수정

### DIFF
--- a/user/.env.example
+++ b/user/.env.example
@@ -9,7 +9,6 @@ DB_PASSWORD=your-mysql-password
 # 생성 방법: openssl rand -base64 32
 JWT_SECRET=your-generated-jwt-secret-key-here
 
-# Redis 접속 정보 (Issue #17 이후 필요)
-# REDIS_HOST=localhost
-# REDIS_PORT=6379
-# REDIS_PASSWORD=
+# Redis 접속 정보
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// .env 파일 로드
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/user/src/main/java/com/high/user/domain/entity/User.java
+++ b/user/src/main/java/com/high/user/domain/entity/User.java
@@ -38,7 +38,10 @@ public class User extends BaseEntity {
     private String phoneNumber;
 
     @Column(length = 255)
-    private String address;
+    private String deliveryAddress;
+
+    @Column(length = 255)
+    private String detailAddress;
 
     @Column(nullable = false)
     private Boolean isActive;
@@ -105,8 +108,9 @@ public class User extends BaseEntity {
     }
 
     // Business logic: 주소 수정
-    public void updateAddress(String address) {
-        this.address = address;
+    public void updateAddress(String deliveryAddress, String detailAddress) {
+        this.deliveryAddress = deliveryAddress;
+        this.detailAddress = detailAddress;
     }
 
     // Business logic: 권한 변경 (MASTER만 변경 불가)

--- a/user/src/main/java/com/high/user/infrastructure/config/JpaAuditingConfig.java
+++ b/user/src/main/java/com/high/user/infrastructure/config/JpaAuditingConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -19,16 +20,16 @@ public class JpaAuditingConfig {
             // SecurityContext에서 인증 정보 추출
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-            // 인증되지 않은 경우 또는 익명 사용자인 경우 "SYSTEM" 반환
-            if (authentication == null || !authentication.isAuthenticated()
-                || "anonymousUser".equals(authentication.getPrincipal())) {
-                return Optional.of("SYSTEM");
+            // 인증되지 않은 경우 또는 익명 사용자인 경우 "anonymous" 반환
+            if (authentication == null ||
+                !authentication.isAuthenticated() ||
+                authentication instanceof AnonymousAuthenticationToken) {
+                return Optional.of("anonymous");
             }
 
-            // 인증된 사용자의 이름(userId) 반환
-            // Issue #14(JWT 인증) 구현 후 JWT에서 userId 추출하도록 수정 예정
-            String username = authentication.getName();
-            return Optional.of(username);
+            // 인증된 사용자의 userId 반환 (JWT에서 추출된 값)
+            String userId = authentication.getName();
+            return Optional.of(userId);
         };
     }
 }


### PR DESCRIPTION
## Issue Number
- Closes #31

## 📝 Description

User Entity의 주소 필드를 개선하고, Auditing 로직을 SecurityContext 기반으로 수정했습니다.

**주요 변경사항:**
1. **주소 필드 분리**: `address` 삭제 → `deliveryAddress` + `detailAddress` (Order Service 패턴 적용)
2. **Auditing 개선**: "SYSTEM" 하드코딩 제거, SecurityContext 기반 userId 추출
3. **타 서비스 호환성**: 익명 사용자의 경우 "anonymous" 반환 (팀원 피드백 반영)

**변경 파일:**
```
user/src/main/java/com/high/user/
├── domain/entity/User.java                    # 주소 필드 분리
└── infrastructure/config/JpaAuditingConfig.java # Auditing 로직 개선
```

**데이터베이스 스키마 변경:**
- `address` 컬럼 삭제
- `delivery_address` 컬럼 추가 (varchar(255))
- `detail_address` 컬럼 추가 (varchar(255))

## 🌐 Test Result

- 생략, #15에서 test 할 예정입니다.

## 🔎 To Reviewer

1. **주소 필드 분리** - Order Service와 동일한 패턴(`deliveryAddress` + `detailAddress`)을 적용했습니다.

2. **Auditing 로직** - SecurityContext에서 userId를 추출하도록 개선했습니다. 인증되지 않은 경우(회원가입 시) `"anonymous"`를 반환하며, 인증된 경우 JWT에서 추출한 userId가 자동으로 저장됩니다.