### PR TITLE
feat: 쿠폰 복원(주문/결제 취소 시) internal 구현

### DIFF
--- a/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
@@ -93,6 +93,19 @@ public class CouponIssueService {
         return CouponUseResponse.from(couponIssue);
     }
 
+    // 쿠폰 복원 처리 (주문/결제 취소)
+    @Transactional
+    public CouponUseResponse restoreCoupon(UUID couponIssueId) {
+        CouponIssue couponIssue = getCouponIssue(couponIssueId);
+
+        LocalDateTime now = LocalDateTime.now();
+        couponIssue.restoreCoupon(now);
+
+        log.info("[INTERNAL] Coupon-Issue-Service - 쿠폰 복원 : couponIssueId={}", couponIssueId);
+
+        return CouponUseResponse.from(couponIssue);
+    }
+
 
     /** -----------------------
      * 쿠폰 발급 이력 ID 조회 메서드

--- a/coupon/src/main/java/com/high/coupon/application/dto/response/CouponRestoreResponse.java
+++ b/coupon/src/main/java/com/high/coupon/application/dto/response/CouponRestoreResponse.java
@@ -1,0 +1,27 @@
+package com.high.coupon.application.dto.response;
+
+import com.high.coupon.domain.entity.CouponIssue;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CouponRestoreResponse(
+        UUID couponIssueId,
+        UUID userId,
+        Boolean isUsed, // 상태
+        LocalDateTime usedAt, // 사용 시간 초기화
+        LocalDateTime validStartAt,
+        LocalDateTime ValidEndAt,
+        LocalDateTime updatedAt
+) {
+    public static CouponRestoreResponse from(CouponIssue couponIssue){
+        return new CouponRestoreResponse(
+                couponIssue.getId(),
+                couponIssue.getUserId(),
+                couponIssue.getIsUsed(),
+                couponIssue.getUsedAt(),
+                couponIssue.getValidStartAt(),
+                couponIssue.getValidEndAt(),
+                couponIssue.getUpdatedAt()
+        );
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/domain/entity/Coupon.java
+++ b/coupon/src/main/java/com/high/coupon/domain/entity/Coupon.java
@@ -2,6 +2,8 @@ package com.high.coupon.domain.entity;
 
 import com.high.coupon.domain.exception.CouponInvalidDateException;
 import com.high.coupon.domain.exception.CouponInvalidDiscountRateException;
+import com.high.coupon.domain.exception.CouponInvalidIssuePeriodException;
+import com.high.coupon.domain.exception.CouponInvalidValidUntilException;
 import com.library.jpa.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -73,14 +75,21 @@ public class Coupon extends BaseEntity {
 
     /**
      * 날짜 검증 메서드
-     * todo: 예외처리 추가 검토 필요
      */
     private static void validateDates(LocalDateTime issueStartAt, LocalDateTime issueEndAt, LocalDateTime validUntil) {
+        // null 체크
         if (issueStartAt == null || issueEndAt == null || validUntil == null) {
             throw new CouponInvalidDateException();
         }
-        if (issueEndAt.isBefore(issueStartAt) || validUntil.isBefore(issueStartAt)) {
-            throw new CouponInvalidDateException();
+
+        // 발행 기간 검증 (발행 종료일이 발행 시작일 보다 이전이면 안 됨)
+        if (issueEndAt.isBefore(issueStartAt)) {
+            throw new CouponInvalidIssuePeriodException();
+        }
+
+        // 유효기간 검증 (유효기간은 발행 종료 이후여야 함)
+        if (validUntil.isBefore(issueEndAt)) {
+            throw new CouponInvalidValidUntilException();
         }
     }
 

--- a/coupon/src/main/java/com/high/coupon/domain/entity/CouponIssue.java
+++ b/coupon/src/main/java/com/high/coupon/domain/entity/CouponIssue.java
@@ -1,6 +1,7 @@
 package com.high.coupon.domain.entity;
 
 import com.high.coupon.domain.exception.CouponAlreadyUsedException;
+import com.high.coupon.domain.exception.CouponExpiredException;
 import com.high.coupon.domain.exception.CouponIssuePeriodInvalidException;
 import com.high.coupon.domain.exception.CouponNotOwnedException;
 import com.high.coupon.domain.exception.CouponNotValidPeriodException;
@@ -22,7 +23,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Entity
 @Getter
 @Builder
@@ -105,4 +108,28 @@ public class CouponIssue extends BaseEntity {
         this.isUsed = true;
         this.usedAt = now;
     }
+
+
+    /**
+     * 주문 / 결제 취소 시 쿠폰 복원
+     * 동일한 유효기간 이내에서만 복원 가능
+     */
+    public void restoreCoupon(LocalDateTime now) {
+
+        if (Boolean.FALSE.equals(this.isUsed) || this.usedAt == null) {
+            // 이미 사용 가능 상태이거나, 사용 기록이 없는 쿠폰은 종료 (ex. 사용 실패 후 재시도)
+            log.info("Coupon {} is already unused or has no used record.", this.id);
+            return;
+        }
+
+        // 유효기간 체크 (동일한 유효기간 이내에서만 복원 가능)
+        if (now.isAfter(this.validEndAt)) {
+            // 유효기간이 만료된 후에는 복원되지 않음
+            throw new CouponExpiredException();
+        }
+
+        this.isUsed = false; // true -> false 복원
+        this.usedAt = null;
+    }
+
 }

--- a/coupon/src/main/java/com/high/coupon/domain/exception/CouponExpiredException.java
+++ b/coupon/src/main/java/com/high/coupon/domain/exception/CouponExpiredException.java
@@ -1,0 +1,11 @@
+package com.high.coupon.domain.exception;
+
+import com.high.coupon.exception.CouponErrorCode;
+import com.library.module.exception.CustomException;
+
+public class CouponExpiredException extends CustomException {
+
+    public CouponExpiredException() {
+        super(CouponErrorCode.COUPON_EXPIRED);
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/domain/exception/CouponInvalidIssuePeriodException.java
+++ b/coupon/src/main/java/com/high/coupon/domain/exception/CouponInvalidIssuePeriodException.java
@@ -1,0 +1,11 @@
+package com.high.coupon.domain.exception;
+
+import com.high.coupon.exception.CouponErrorCode;
+import com.library.module.exception.CustomException;
+
+public class CouponInvalidIssuePeriodException extends CustomException {
+
+    public CouponInvalidIssuePeriodException() {
+        super(CouponErrorCode.COUPON_INVALID_ISSUE_PERIOD);
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/domain/exception/CouponInvalidValidUntilException.java
+++ b/coupon/src/main/java/com/high/coupon/domain/exception/CouponInvalidValidUntilException.java
@@ -1,0 +1,11 @@
+package com.high.coupon.domain.exception;
+
+import com.high.coupon.exception.CouponErrorCode;
+import com.library.module.exception.CustomException;
+
+public class CouponInvalidValidUntilException extends CustomException {
+
+    public CouponInvalidValidUntilException() {
+        super(CouponErrorCode.COUPON_INVALID_VALID_UNTIL);
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/exception/CouponErrorCode.java
+++ b/coupon/src/main/java/com/high/coupon/exception/CouponErrorCode.java
@@ -18,15 +18,20 @@ public enum CouponErrorCode implements BaseErrorCode {
     COUPON_OUT_OF_STOCK(6001, HttpStatus.BAD_REQUEST, "쿠폰이 모두 소진되었습니다."),
     COUPON_ISSUE_NOT_FOUND(6002, HttpStatus.NOT_FOUND, "존재하지 않는 쿠폰 발급 내역입니다."),
 
-    // domain 6500 ~ todo 사용하지 않는 에러코드 정리 예정
+    // domain 6500 ~ todo (user 연동 후 확인 필요)
     COUPON_ISSUE_PERIOD_INVALID(6500, HttpStatus.BAD_REQUEST, "쿠폰 발급 기간이 아닙니다."),
     COUPON_ALREADY_ISSUED(6501, HttpStatus.BAD_REQUEST, "이미 발급이 완료 된 쿠폰입니다."),
     COUPON_ALREADY_USED(6502, HttpStatus.BAD_REQUEST, "이미 사용된 쿠폰입니다."),
-    COUPON_NOT_OWNED(6503, HttpStatus.FORBIDDEN, "해당 사용자의 쿠폰이 아닙니다."),
+    COUPON_NOT_OWNED(6503, HttpStatus.FORBIDDEN, "쿠폰 사용 권한이 없습니다."),
+
     COUPON_NOT_VALID_PERIOD(6504, HttpStatus.BAD_REQUEST, "쿠폰 사용 가능 기간이 아닙니다. 유효 기간을 확인해주세요."),
-    COUPON_INVALID_DATE(6505, HttpStatus.BAD_REQUEST, "쿠폰 발행/유효 기간이 잘못되었습니다."),
+    COUPON_INVALID_DATE(6505, HttpStatus.BAD_REQUEST, "쿠폰 발행/유효 기간을 입력해주세요"),
     COUPON_INVALID_DISCOUNT_RATE(6506, HttpStatus.BAD_REQUEST, "쿠폰 할인율은 1~100% 사이여야 하며, 소수점은 허용되지 않습니다."),
+
     COUPON_EXPIRED(6505, HttpStatus.BAD_REQUEST, "쿠폰 사용 기간이 만료되어 복원되지 않습니다."),
+
+    COUPON_INVALID_ISSUE_PERIOD(6507, HttpStatus.BAD_REQUEST, "발행 종료일이 시작일보다 이전입니다."),
+    COUPON_INVALID_VALID_UNTIL(6508, HttpStatus.BAD_REQUEST, "유효기간이 발행 종료일보다 이전입니다."),
 
     ;
     private final int code;

--- a/coupon/src/main/java/com/high/coupon/exception/CouponErrorCode.java
+++ b/coupon/src/main/java/com/high/coupon/exception/CouponErrorCode.java
@@ -23,9 +23,10 @@ public enum CouponErrorCode implements BaseErrorCode {
     COUPON_ALREADY_ISSUED(6501, HttpStatus.BAD_REQUEST, "이미 발급이 완료 된 쿠폰입니다."),
     COUPON_ALREADY_USED(6502, HttpStatus.BAD_REQUEST, "이미 사용된 쿠폰입니다."),
     COUPON_NOT_OWNED(6503, HttpStatus.FORBIDDEN, "해당 사용자의 쿠폰이 아닙니다."),
-    COUPON_NOT_VALID_PERIOD(6504, HttpStatus.BAD_REQUEST, "쿠폰 유효 기간이 아닙니다."),
+    COUPON_NOT_VALID_PERIOD(6504, HttpStatus.BAD_REQUEST, "쿠폰 사용 가능 기간이 아닙니다. 유효 기간을 확인해주세요."),
     COUPON_INVALID_DATE(6505, HttpStatus.BAD_REQUEST, "쿠폰 발행/유효 기간이 잘못되었습니다."),
-    COUPON_INVALID_DISCOUNT_RATE(6506, HttpStatus.BAD_REQUEST, "쿠폰 할인율은 1~100% 사이여야 하며, 소수점은 허용되지 않습니다.");
+    COUPON_INVALID_DISCOUNT_RATE(6506, HttpStatus.BAD_REQUEST, "쿠폰 할인율은 1~100% 사이여야 하며, 소수점은 허용되지 않습니다."),
+    COUPON_EXPIRED(6505, HttpStatus.BAD_REQUEST, "쿠폰 사용 기간이 만료되어 복원되지 않습니다."),
 
     ;
     private final int code;

--- a/coupon/src/main/java/com/high/coupon/presentation/internal/CouponInternalController.java
+++ b/coupon/src/main/java/com/high/coupon/presentation/internal/CouponInternalController.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,6 +44,18 @@ public class CouponInternalController {
             @RequestParam UUID userId
     ) {
         CouponUseResponse response = couponIssueService.useCoupon(couponIssueId, userId);
+        return ApiResponse.success(response);
+    }
+
+    /**
+     * 쿠폰 복원 처리 (주문/결제 취소 시 유효기간 이내 재발급)
+     * POST /api/v1/internal/coupons/{couponIssuedId}/restore
+     */
+    @PostMapping("/{couponIssueId}/restore")
+    public ApiResponse<CouponUseResponse> restoreCoupon(
+            @PathVariable UUID couponIssueId) {
+
+        CouponUseResponse response = couponIssueService.restoreCoupon(couponIssueId);
         return ApiResponse.success(response);
     }
 }


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #39 

## 📝 Description
- 쿠폰 복원 (주문/결제 취소 시 사용) internal 구현
- `POST /api/v1/internal/coupons/{couponIssuedId}/restore`
- 네이버 쿠폰 복원 정책을 참고해 **쿠폰의 유효 기간 이내에만 재발급 가능하도록 설계**
<details>
<summary>참고: 네이버 쇼핑 공지사항 🛍️</summary>

**1. 유효기간 이내: 동일한 유효기간으로 횟수 제한 없이 재발급 ✅****
2. 유효기간 만료: 판매자 귀책으로 인한 취소 건에 한해서만 횟수 제한 없이 재발급, 쿠폰의 유효기간은 취소 시점으로부터 24시간 연장

(이벤트 기간이 종료된 이후 재발행된 쿠폰은 사용이 불가합니다.)

구매자 귀책(단순변심 등) 취소 시 쿠폰 소멸
판매자 귀책(상품품절 등) 취소 시 사용취소 시점+1일(24시간) 연장되어 재발급

</details>


## 🌐 Test Result

- **상태 복원 완료 (true -> false)**

<img width="990" height="715" alt="스크린샷 2025-12-03 191358" src="https://github.com/user-attachments/assets/3ec6a324-cd65-4c32-873a-24ccaafc6083" />

- **유효기간 만료 복원 X**

<img width="988" height="664" alt="스크린샷 2025-12-03 192121" src="https://github.com/user-attachments/assets/6d997955-85ee-4831-bcf7-11376594ebcb" />


## 🔎 To Reviewer
- 다른 서비스 쪽에서 더 필요한 데이터 있으시면 말해주세요 👻...
