### PR TITLE
feat: Gateway - JWT Authentication Filter 구현

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -117,12 +117,17 @@ services:
     ports:
       - "8000:8000"
     depends_on:
+      redis:
+        condition: service_started
       eureka-server:
         condition: service_healthy
     networks:
       - msa-network
     environment:
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://eureka-server:8761/eureka/
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      JWT_SECRET: ${JWT_SECRET}
 
   # 7. User Service (사용자 관리)
   user-service:

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -22,6 +22,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 ext {
@@ -30,11 +31,23 @@ ext {
 
 dependencies {
 
+	// Common Libraries
+	implementation 'com.github.sharedeffort:common-module:v1.1.9'
+
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.13'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+	// JWT dependencies (same version as User Service)
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Redis Reactive dependencies
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/gateway/src/main/java/com/high/gateway/config/RedisConfig.java
+++ b/gateway/src/main/java/com/high/gateway/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.high.gateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Redis Reactive Configuration
+ * ReactiveRedisTemplate 설정 for JWT blacklist checking
+ */
+@Configuration
+public class RedisConfig {
+
+    /**
+     * ReactiveRedisTemplate Bean 생성
+     * String key/value serializer 사용
+     */
+    @Bean
+    public ReactiveRedisTemplate<String, String> reactiveRedisTemplate(
+            ReactiveRedisConnectionFactory connectionFactory) {
+
+        StringRedisSerializer serializer = new StringRedisSerializer();
+
+        RedisSerializationContext<String, String> serializationContext =
+                RedisSerializationContext.<String, String>newSerializationContext(serializer)
+                        .key(serializer)
+                        .value(serializer)
+                        .hashKey(serializer)
+                        .hashValue(serializer)
+                        .build();
+
+        return new ReactiveRedisTemplate<>(connectionFactory, serializationContext);
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/config/SecurityConfig.java
+++ b/gateway/src/main/java/com/high/gateway/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.high.gateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Security Configuration
+ * CORS 설정
+ */
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public CorsWebFilter corsWebFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        // Allow origins (개발 환경: 모든 origin 허용, 운영 환경에서는 특정 도메인만 허용)
+        config.setAllowedOriginPatterns(List.of("*"));
+
+        // Allow methods
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+
+        // Allow headers
+        config.setAllowedHeaders(Arrays.asList(
+                "Authorization",
+                "Content-Type",
+                "X-User-Id",
+                "X-User-Role"
+        ));
+
+        // Expose headers (클라이언트에서 접근 가능한 헤더)
+        config.setExposedHeaders(Arrays.asList(
+                "X-User-Id",
+                "X-User-Role"
+        ));
+
+        // Allow credentials
+        config.setAllowCredentials(true);
+
+        // Max age (preflight 요청 캐시 시간)
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsWebFilter(source);
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/exception/ForbiddenException.java
+++ b/gateway/src/main/java/com/high/gateway/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package com.high.gateway.exception;
+
+import com.library.module.exception.CustomException;
+
+/**
+ * Forbidden Exception (403)
+ * 권한 부족 시 발생하는 예외
+ */
+public class ForbiddenException extends CustomException {
+
+    public ForbiddenException(GatewayErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/exception/GatewayErrorCode.java
+++ b/gateway/src/main/java/com/high/gateway/exception/GatewayErrorCode.java
@@ -1,0 +1,30 @@
+package com.high.gateway.exception;
+
+import com.library.module.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Gateway Error Code Enum
+ * Gateway에서 발생하는 에러 코드 정의
+ * Error Code Range: 9000-9999
+ */
+@Getter
+@RequiredArgsConstructor
+public enum GatewayErrorCode implements BaseErrorCode {
+
+    // 90xx: JWT Authentication Errors
+    INVALID_TOKEN(9000, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    EXPIRED_TOKEN(9001, HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
+    TOKEN_NOT_FOUND(9002, HttpStatus.UNAUTHORIZED, "요청에 토큰이 없습니다"),
+    BLACKLISTED_TOKEN(9003, HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다"),
+
+    // 91xx: Authorization Errors
+    UNAUTHORIZED(9100, HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다"),
+    FORBIDDEN(9101, HttpStatus.FORBIDDEN, "접근 권한이 없습니다");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/gateway/src/main/java/com/high/gateway/exception/GlobalExceptionHandler.java
+++ b/gateway/src/main/java/com/high/gateway/exception/GlobalExceptionHandler.java
@@ -1,0 +1,85 @@
+package com.high.gateway.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.library.module.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Global Exception Handler for Gateway (WebFlux)
+ * CustomException 기반 예외 처리 (common-module 패턴 준수)
+ *
+ * Note: Gateway는 WebFlux이므로 ErrorWebExceptionHandler를 직접 구현
+ * (common-module의 @RestControllerAdvice는 Spring MVC용)
+ */
+@Slf4j
+@Order(-1)
+@Configuration
+@RequiredArgsConstructor
+public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        log.error("Exception occurred: {}", ex.getMessage(), ex);
+
+        HttpStatus status;
+        int code;
+        String message;
+
+        // CustomException 처리 (common-module 패턴)
+        if (ex instanceof CustomException) {
+            CustomException customException = (CustomException) ex;
+            status = customException.getBaseErrorCode().getStatus();
+            code = customException.getBaseErrorCode().getCode();
+            message = customException.getBaseErrorCode().getMessage();
+        } else {
+            // 기타 예외는 500 처리
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+            code = 5000;
+            message = "서버 내부 오류가 발생했습니다";
+        }
+
+        return writeErrorResponse(exchange, status, code, message);
+    }
+
+    /**
+     * 에러 응답 작성 (common-module 응답 형식 준수)
+     * {
+     *   "success": false,
+     *   "code": 9000,
+     *   "message": "유효하지 않은 토큰입니다"
+     * }
+     */
+    private Mono<Void> writeErrorResponse(ServerWebExchange exchange, HttpStatus status, int code, String message) {
+        exchange.getResponse().setStatusCode(status);
+        exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("success", false);
+        errorResponse.put("code", code);
+        errorResponse.put("message", message);
+
+        try {
+            byte[] bytes = objectMapper.writeValueAsBytes(errorResponse);
+            DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(bytes);
+            return exchange.getResponse().writeWith(Mono.just(buffer));
+        } catch (JsonProcessingException e) {
+            log.error("Error writing error response: {}", e.getMessage());
+            return exchange.getResponse().setComplete();
+        }
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/exception/UnauthorizedException.java
+++ b/gateway/src/main/java/com/high/gateway/exception/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package com.high.gateway.exception;
+
+import com.library.module.exception.CustomException;
+
+/**
+ * Unauthorized Exception (401)
+ * 인증 실패 시 발생하는 예외
+ */
+public class UnauthorizedException extends CustomException {
+
+    public UnauthorizedException(GatewayErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/filter/JwtAuthenticationGlobalFilter.java
+++ b/gateway/src/main/java/com/high/gateway/filter/JwtAuthenticationGlobalFilter.java
@@ -1,0 +1,114 @@
+package com.high.gateway.filter;
+
+import com.high.gateway.exception.GatewayErrorCode;
+import com.high.gateway.exception.UnauthorizedException;
+import com.high.gateway.service.JwtTokenValidator;
+import com.high.gateway.service.TokenBlacklistService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * JWT Authentication Global Filter
+ * 모든 요청에 대한 JWT 검증 수행
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationGlobalFilter implements GlobalFilter, Ordered {
+
+    private final JwtTokenValidator jwtTokenValidator;
+    private final TokenBlacklistService tokenBlacklistService;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    // 인증 제외 경로
+    private static final List<String> EXCLUDED_PATHS = List.of(
+            "/api/v1/users/signup",
+            "/api/v1/users/login",
+            "/docs",
+            "/docs/**",
+            "/actuator/**",
+            "/**/v3/api-docs",
+            "/**/v3/api-docs/**"
+    );
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String path = exchange.getRequest().getURI().getPath();
+
+        // 제외 경로 확인
+        if (isExcludedPath(path)) {
+            log.debug("Excluded path accessed: {}", path);
+            return chain.filter(exchange);
+        }
+
+        // Authorization 헤더에서 토큰 추출
+        String token = extractToken(exchange.getRequest());
+        if (token == null) {
+            log.warn("Token not found in request: {}", path);
+            throw new UnauthorizedException(GatewayErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        // JWT 검증
+        if (!jwtTokenValidator.validateToken(token)) {
+            log.warn("Invalid token for path: {}", path);
+            throw new UnauthorizedException(GatewayErrorCode.INVALID_TOKEN);
+        }
+
+        // 블랙리스트 확인 (비동기)
+        return tokenBlacklistService.isBlacklisted(token)
+                .flatMap(isBlacklisted -> {
+                    if (isBlacklisted) {
+                        log.warn("Blacklisted token used for path: {}", path);
+                        return Mono.error(new UnauthorizedException(GatewayErrorCode.BLACKLISTED_TOKEN));
+                    }
+
+                    // 사용자 정보 추출 및 헤더 추가
+                    String userId = jwtTokenValidator.getUserId(token);
+                    String role = jwtTokenValidator.getRole(token);
+
+                    ServerHttpRequest modifiedRequest = exchange.getRequest().mutate()
+                            .header("X-User-Id", userId)
+                            .header("X-User-Role", role)
+                            .build();
+
+                    log.debug("Authenticated request - Path: {}, UserId: {}, Role: {}", path, userId, role);
+
+                    return chain.filter(exchange.mutate().request(modifiedRequest).build());
+                });
+    }
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰 추출
+     */
+    private String extractToken(ServerHttpRequest request) {
+        String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * 제외 경로 확인
+     */
+    private boolean isExcludedPath(String path) {
+        return EXCLUDED_PATHS.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/service/JwtTokenValidator.java
+++ b/gateway/src/main/java/com/high/gateway/service/JwtTokenValidator.java
@@ -1,0 +1,93 @@
+package com.high.gateway.service;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * JWT Token Validator
+ * JWT 파싱 및 검증 담당 (User Service의 JwtTokenProvider와 동일한 방식)
+ */
+@Slf4j
+@Component
+public class JwtTokenValidator {
+
+    @Value("${spring.security.jwt.secret}")
+    private String secretKeyString;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    protected void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
+        log.info("JwtTokenValidator initialized with key length: {} bytes",
+                secretKeyString.getBytes(StandardCharsets.UTF_8).length);
+    }
+
+    /**
+     * 토큰 유효성 검증
+     * @param token JWT 토큰
+     * @return 유효성 여부
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * 토큰에서 사용자 ID 추출
+     * @param token JWT 토큰
+     * @return 사용자 ID (String)
+     */
+    public String getUserId(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getSubject();
+    }
+
+    /**
+     * 토큰에서 권한 추출
+     * @param token JWT 토큰
+     * @return 사용자 권한
+     */
+    public String getRole(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("role", String.class);
+    }
+
+    /**
+     * Claims 파싱 (만료된 토큰도 파싱 가능)
+     * @param token JWT 토큰
+     * @return Claims 객체
+     */
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/service/TokenBlacklistService.java
+++ b/gateway/src/main/java/com/high/gateway/service/TokenBlacklistService.java
@@ -1,0 +1,41 @@
+package com.high.gateway.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+/**
+ * Token Blacklist Service
+ * Redis에서 블랙리스트 토큰 확인 (User Service의 RefreshTokenService와 동일한 키 패턴 사용)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private static final String BLACKLIST_PREFIX = "blacklist:";
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+    /**
+     * 토큰이 블랙리스트에 등록되어 있는지 확인
+     * @param token JWT 토큰
+     * @return 블랙리스트 등록 여부 (Mono<Boolean>)
+     */
+    public Mono<Boolean> isBlacklisted(String token) {
+        String key = BLACKLIST_PREFIX + token;
+        return reactiveRedisTemplate.hasKey(key)
+                .doOnNext(exists -> {
+                    if (exists) {
+                        log.warn("Blacklisted token detected: {}", token.substring(0, Math.min(20, token.length())));
+                    }
+                })
+                .onErrorResume(e -> {
+                    log.error("Error checking blacklist for token: {}", e.getMessage());
+                    // Redis 연결 오류 시 안전을 위해 true 반환 (접근 거부)
+                    return Mono.just(true);
+                });
+    }
+}

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -15,6 +15,18 @@ spring:
     web-application-type: reactive
   application:
     name: gateway-service
+
+  # Redis configuration
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  # JWT configuration
+  security:
+    jwt:
+      secret: ${JWT_SECRET:local-dev-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm}
+
   cloud:
     gateway:
       server:


### PR DESCRIPTION
## Issue Number
- Closes #40 (Gateway JWT Authentication Filter)

## 📝 Description

Gateway에 JWT 인증 필터를 구현하여 모든 API 요청에 대한 토큰 검증 및 사용자 정보 전달 기능을 추가했습니다.

**구현 내용:**

**1. JWT 토큰 검증**
- JJWT 0.11.5 라이브러리 사용 (User Service와 동일 버전)
- User Service와 동일한 Secret Key 공유 (환경 변수)
- 토큰 유효성 검증 (서명, 만료, 형식)

**2. Redis 블랙리스트 체크**
- 로그아웃된 토큰 차단
- ReactiveRedisTemplate 사용 (WebFlux 비동기 처리)
- 블랙리스트 키 패턴: `blacklist:{token}` (User Service와 동일)

**3. 사용자 정보 헤더 전달**
- 다운스트림 서비스로 사용자 정보 전달
- `X-User-Id`: 사용자 ID
- `X-User-Role`: 사용자 권한 (USER, SELLER, MASTER)

**4. 인증 제외 경로 설정**
- `/api/v1/users/signup` - 회원가입
- `/api/v1/users/login` - 로그인
- `/docs`, `/docs/**` - Swagger UI
- `/actuator/**` - Spring Actuator
- `/**/v3/api-docs`, `/**/v3/api-docs/**` - OpenAPI 문서

**5. 예외 처리 (common-module 패턴 준수)**
- Gateway 전용 에러 코드 범위: 9000-9999
- `GatewayErrorCode` enum 구현 (BaseErrorCode 인터페이스)
- WebFlux 호환 GlobalExceptionHandler (ErrorWebExceptionHandler)
- 표준 응답 형식: `{ "success": false, "code": 9000, "message": "..." }`

**6. Docker 환경 설정**
- `docker-compose.dev.yml`에 Gateway 환경 변수 추가
- Redis 의존성 설정
- JWT Secret 환경 변수 주입

**구현 파일:**
```
gateway/build.gradle                                # JJWT, Redis Reactive, common-module 의존성
gateway/src/main/resources/application.yaml         # Redis, JWT 설정
gateway/src/main/java/com/high/gateway/
  ├─ config/
  │  ├─ RedisConfig.java                           # ReactiveRedisTemplate 빈 설정
  │  └─ SecurityConfig.java                        # CORS 설정
  ├─ service/
  │  ├─ JwtTokenValidator.java                     # JWT 검증 서비스
  │  └─ TokenBlacklistService.java                 # Redis 블랙리스트 체크
  ├─ filter/
  │  └─ JwtAuthenticationGlobalFilter.java         # 인증 필터 (Order: HIGHEST_PRECEDENCE)
  └─ exception/
     ├─ GatewayErrorCode.java                      # 에러 코드 정의 (9000-9999)
     ├─ UnauthorizedException.java                 # 401 예외
     ├─ ForbiddenException.java                    # 403 예외
     └─ GlobalExceptionHandler.java                # WebFlux 예외 처리
docker-compose.dev.yml                             # Gateway 환경 변수 추가
docs/03.conventions/04.error-code-convention.md    # Gateway 에러 코드 문서화
```

**Gateway 에러 코드 (9000-9999):**

| Code | Status | Message |
|------|--------|---------|
| 9000 | 401 | 유효하지 않은 토큰입니다 |
| 9001 | 401 | 만료된 토큰입니다 |
| 9002 | 401 | 요청에 토큰이 없습니다 |
| 9003 | 401 | 로그아웃된 토큰입니다 |
| 9100 | 401 | 인증되지 않은 접근입니다 |
| 9101 | 403 | 접근 권한이 없습니다 |
| 9200 | 429 | 요청 횟수 제한을 초과했습니다 (Issue #41 예약) |

## 🌐 Test Result

### Postman 테스트

#### Test 1: 토큰 없이 요청 (401 에러)
<img width="349" height="521" alt="image" src="https://github.com/user-attachments/assets/90e7d110-1160-4bd9-a9ab-fe8384a09f93" />

---

#### Test 2: 회원가입 (인증 제외 경로)
<img width="477" height="596" alt="image" src="https://github.com/user-attachments/assets/290e6481-2f20-4578-8eb7-88a60978c656" />

---

#### Test 3: 유효한 토큰으로 인증 요청 (성공)
<img width="1659" height="597" alt="image" src="https://github.com/user-attachments/assets/2feaeb4a-754e-4f6a-bcdf-a2981941dd5f" />

<img width="365" height="508" alt="image" src="https://github.com/user-attachments/assets/edbaf4ff-0ce6-4ed6-bdb2-98aead7340ba" />
---

#### Test 4: 로그아웃 후 토큰 재사용 (401 에러)
<img width="365" height="523" alt="image" src="https://github.com/user-attachments/assets/ab9aac21-7b8c-404f-b6db-2f40d29df5c7" />

---

## 🔎 To Reviewer

1. 예외 처리 구현 이상없는지 확인 부탁드립니다.
2. **GlobalFilter 우선순위:** JWT 인증 필터를 `HIGHEST_PRECEDENCE`로 설정했는데, 향후 Rate Limiting 필터와의 우선순위 조정이 필요할까요?
3. **블랙리스트 체크 실패 시 처리:** Redis 연결 오류 시 `fail-safe`로 모든 요청을 차단하도록 구현했습니다. 이 정책이 적절한지 검토 부탁드립니다.