### PR TITLE
feat: Gateway - Rate Limiting 구현&User Service - 내 정보 조회 API (GET /me)

### DIFF
--- a/config/src/main/resources/config-repo/user-service.yml
+++ b/config/src/main/resources/config-repo/user-service.yml
@@ -29,8 +29,8 @@ spring:
   security:
     jwt:
       secret: ${JWT_SECRET:change-this-secret-key-in-production-must-be-at-least-256-bits-long}
-      access-token-validity: 3600000  # 1 hour
-      refresh-token-validity: 604800000  # 7 days
+      access-token-validity: 86400000  # 24시간 (개발 환경용, 프로덕션: 3600000 = 1시간)
+      refresh-token-validity: 2592000000  # 30일 (개발 환경용, 프로덕션: 604800000 = 7일)
 
 management:
   zipkin:

--- a/gateway/scripts/rate-limiting-test-result-1764859515.txt
+++ b/gateway/scripts/rate-limiting-test-result-1764859515.txt
@@ -1,0 +1,53 @@
+Gateway Rate Limiting Test Result
+Test Date: 2025-12-04 23:45:15
+========================================
+
+[Test 0] 회원가입
+✓ 회원가입 성공
+Email: test_1764859515@example.com
+
+[Test 1] JWT 토큰 획득 (로그인)
+✓ 토큰 획득 성공
+Token: eyJhbGciOiJIUzI1NiJ9...
+
+[Test 2] 정상 요청 - Rate Limit 헤더 확인
+HTTP Status: 200
+X-RateLimit-Limit: 10
+X-RateLimit-Remaining: 9
+✓ 정상 요청 성공, Rate Limit 헤더 확인됨
+
+[Test 3] 10번 연속 요청 - 토큰 소진
+성공: 10/10
+실패: 0/10
+✓ 10번 요청 모두 성공
+
+[Test 4] 11번째 요청 - Rate Limit 초과 확인
+HTTP Status: 429
+Retry-After: 1
+Response Body: {"code":9200,"retryAfter":1,"success":false,"message":"요청 한도를 초과했습니다"}
+✓ 429 Too Many Requests 응답 확인
+Error Code: 9200
+Error Message: 요청 한도를 초과했습니다
+Retry After (body): 1
+✓ 올바른 에러 코드 (9200)
+
+[Test 5] 토큰 리필 확인 (10초 대기)
+HTTP Status: 200
+X-RateLimit-Remaining: 9
+✓ 요청 성공 (토큰 리필됨)
+리필된 토큰: 10개 (refill-rate: 1 token/sec × 10 sec)
+남은 토큰: 9 (10 - 1)
+
+========================================
+Test Summary
+========================================
+✓ Test 0: 회원가입
+✓ Test 1: JWT 토큰 획득
+✓ Test 2: Rate Limit 헤더 확인
+✓ Test 3: 10번 연속 요청 성공
+✓ Test 4: 11번째 요청 429 응답
+✓ Test 5: 토큰 리필 확인
+
+🎉 모든 테스트 성공! Rate Limiting이 정상 동작합니다.
+
+결과 파일: /c/Users/gy990/OneDrive/GYP/14.Master_Java/02.workspace/high-tension/gateway/scripts/rate-limiting-test-result-1764859515.txt

--- a/gateway/scripts/rate-limiting-test.sh
+++ b/gateway/scripts/rate-limiting-test.sh
@@ -1,0 +1,333 @@
+#!/bin/bash
+
+# ==============================================================================
+# Gateway Rate Limiting 테스트 스크립트
+# ==============================================================================
+# 목적: Token Bucket 알고리즘 기반 Rate Limiting 테스트
+# 알고리즘: 10 tokens 용량, 1 token/sec 리필 속도 (테스트 설정)
+# 예상 동작:
+#   - 1-10번째 요청: 200 OK
+#   - 11번째 요청: 429 Too Many Requests
+#   - 10초 대기 후: 200 OK (10개 토큰 리필됨)
+# ==============================================================================
+
+# 색상 코드
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# 설정
+GATEWAY_URL="http://localhost:8000"
+SIGNUP_ENDPOINT="${GATEWAY_URL}/api/v1/users/signup"
+LOGIN_ENDPOINT="${GATEWAY_URL}/api/v1/users/login"
+TEST_ENDPOINT="${GATEWAY_URL}/api/v1/users/me"
+
+# 테스트 사용자 credentials (매번 랜덤 이메일로 새 계정 생성)
+TIMESTAMP=$(date +%s)
+EMAIL="test_${TIMESTAMP}@example.com"
+PASSWORD="password1234@"
+NAME="TestUser${TIMESTAMP}"
+
+# 결과 파일 경로 (scripts 폴더 내)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULT_FILE="${SCRIPT_DIR}/rate-limiting-test-result-${TIMESTAMP}.txt"
+
+# 결과 파일 초기화
+echo "Gateway Rate Limiting Test Result" > "$RESULT_FILE"
+echo "Test Date: $(date '+%Y-%m-%d %H:%M:%S')" >> "$RESULT_FILE"
+echo "========================================" >> "$RESULT_FILE"
+echo "" >> "$RESULT_FILE"
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Gateway Rate Limiting Test${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}결과 파일: ${RESULT_FILE}${NC}"
+echo ""
+
+# 헬퍼 함수: 콘솔과 파일 동시 출력
+log_result() {
+  echo -e "$1"
+  echo "$1" | sed 's/\x1b\[[0-9;]*m//g' >> "$RESULT_FILE"
+}
+
+# 테스트 결과 추적 변수
+TEST0_RESULT=""
+TEST1_RESULT=""
+TEST2_RESULT=""
+TEST3_RESULT=""
+TEST4_RESULT=""
+TEST5_RESULT=""
+
+# ==============================================================================
+# Test 0: 회원가입
+# ==============================================================================
+log_result "[Test 0] 회원가입"
+
+SIGNUP_RESPONSE=$(curl -s -X POST "${SIGNUP_ENDPOINT}" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"${EMAIL}\",\"password\":\"${PASSWORD}\",\"name\":\"${NAME}\",\"phoneNumber\":\"01012345678\",\"role\":\"USER\"}")
+
+SIGNUP_SUCCESS=$(echo "$SIGNUP_RESPONSE" | jq -r '.success')
+
+if [ "$SIGNUP_SUCCESS" = "true" ]; then
+  log_result "✓ 회원가입 성공"
+  log_result "Email: ${EMAIL}"
+  TEST0_RESULT="success"
+else
+  log_result "✗ 회원가입 실패"
+  log_result "Response: ${SIGNUP_RESPONSE}"
+  TEST0_RESULT="fail"
+  exit 1
+fi
+log_result ""
+
+# ==============================================================================
+# Test 1: JWT 토큰 획득
+# ==============================================================================
+log_result "[Test 1] JWT 토큰 획득 (로그인)"
+
+TOKEN=$(curl -s -X POST "${LOGIN_ENDPOINT}" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"${EMAIL}\",\"password\":\"${PASSWORD}\"}" \
+  | jq -r '.data.accessToken')
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  log_result "✗ 토큰 획득 실패"
+  log_result "로그인 엔드포인트를 확인하세요."
+  TEST1_RESULT="fail"
+  exit 1
+fi
+
+log_result "✓ 토큰 획득 성공"
+log_result "Token: ${TOKEN:0:20}..."
+TEST1_RESULT="success"
+log_result ""
+
+# ==============================================================================
+# Test 2: 정상 요청 - Rate Limit 헤더 확인
+# ==============================================================================
+log_result "[Test 2] 정상 요청 - Rate Limit 헤더 확인"
+
+RESPONSE=$(curl -s -v "${TEST_ENDPOINT}" \
+  -H "Authorization: Bearer ${TOKEN}" 2>&1)
+
+# 헤더 추출
+HTTP_STATUS=$(echo "$RESPONSE" | grep "< HTTP" | awk '{print $3}')
+RATE_LIMIT=$(echo "$RESPONSE" | grep -i "< X-RateLimit-Limit:" | awk '{print $3}' | tr -d '\r')
+RATE_REMAINING=$(echo "$RESPONSE" | grep -i "< X-RateLimit-Remaining:" | awk '{print $3}' | tr -d '\r')
+
+log_result "HTTP Status: ${HTTP_STATUS}"
+log_result "X-RateLimit-Limit: ${RATE_LIMIT}"
+log_result "X-RateLimit-Remaining: ${RATE_REMAINING}"
+
+if [ "$HTTP_STATUS" = "200" ] && [ "$RATE_LIMIT" = "10" ]; then
+  log_result "✓ 정상 요청 성공, Rate Limit 헤더 확인됨"
+  TEST2_RESULT="success"
+else
+  log_result "✗ 예상과 다른 응답"
+  TEST2_RESULT="fail"
+fi
+log_result ""
+
+# ==============================================================================
+# Test 3: 10번 연속 요청 - 토큰 소진
+# ==============================================================================
+log_result "[Test 3] 10번 연속 요청 - 토큰 소진"
+
+# 토큰 리필을 방지하기 위해 2초 대기 (Test 2에서 소진된 토큰이 리필되지 않도록)
+echo "토큰 리필 방지를 위해 2초 대기..."
+sleep 2
+
+echo "요청 중..."
+
+SUCCESS_COUNT=0
+FAIL_COUNT=0
+
+for i in {1..10}; do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${TEST_ENDPOINT}" \
+    -H "Authorization: Bearer ${TOKEN}")
+
+  if [ "$STATUS" = "200" ]; then
+    ((SUCCESS_COUNT++))
+  else
+    ((FAIL_COUNT++))
+  fi
+
+  # 진행 표시
+  if [ $((i % 5)) -eq 0 ]; then
+    echo -n "."
+  fi
+done
+
+echo ""
+log_result "성공: ${SUCCESS_COUNT}/10"
+log_result "실패: ${FAIL_COUNT}/10"
+
+if [ $SUCCESS_COUNT -eq 10 ]; then
+  log_result "✓ 10번 요청 모두 성공"
+  TEST3_RESULT="success"
+else
+  log_result "✗ 일부 요청 실패 (예상: 10번 모두 성공)"
+  TEST3_RESULT="partial_fail"
+fi
+log_result ""
+
+# ==============================================================================
+# Test 4: 11번째 요청 - Rate Limit 초과 확인
+# ==============================================================================
+log_result "[Test 4] 11번째 요청 - Rate Limit 초과 확인"
+
+# 헤더와 바디를 분리하여 저장
+TEMP_HEADERS=$(mktemp)
+TEMP_BODY=$(mktemp)
+
+curl -s -D "$TEMP_HEADERS" -o "$TEMP_BODY" "${TEST_ENDPOINT}" \
+  -H "Authorization: Bearer ${TOKEN}"
+
+# 응답 추출
+HTTP_STATUS=$(head -n 1 "$TEMP_HEADERS" | awk '{print $2}')
+RETRY_AFTER=$(grep -i "Retry-After:" "$TEMP_HEADERS" | awk '{print $2}' | tr -d '\r')
+BODY=$(cat "$TEMP_BODY")
+
+log_result "HTTP Status: ${HTTP_STATUS}"
+log_result "Retry-After: ${RETRY_AFTER}"
+log_result "Response Body: ${BODY}"
+
+if [ "$HTTP_STATUS" = "429" ]; then
+  log_result "✓ 429 Too Many Requests 응답 확인"
+
+  # 에러 응답 형식 확인
+  ERROR_CODE=$(echo "$BODY" | jq -r '.code' 2>/dev/null)
+  ERROR_MESSAGE=$(echo "$BODY" | jq -r '.message' 2>/dev/null)
+  RETRY_AFTER_BODY=$(echo "$BODY" | jq -r '.retryAfter' 2>/dev/null)
+
+  log_result "Error Code: ${ERROR_CODE}"
+  log_result "Error Message: ${ERROR_MESSAGE}"
+  log_result "Retry After (body): ${RETRY_AFTER_BODY}"
+
+  if [ "$ERROR_CODE" = "9200" ]; then
+    log_result "✓ 올바른 에러 코드 (9200)"
+    TEST4_RESULT="success"
+  else
+    log_result "✗ 잘못된 에러 코드 (예상: 9200, 실제: ${ERROR_CODE})"
+    TEST4_RESULT="partial_fail"
+  fi
+else
+  log_result "✗ 예상과 다른 응답 (예상: 429, 실제: ${HTTP_STATUS})"
+  TEST4_RESULT="fail"
+fi
+
+# 임시 파일 정리
+rm -f "$TEMP_HEADERS" "$TEMP_BODY"
+
+log_result ""
+
+# ==============================================================================
+# Test 5: 토큰 리필 확인 (10초 대기)
+# ==============================================================================
+log_result "[Test 5] 토큰 리필 확인 (10초 대기)"
+echo "대기 중..."
+
+for i in {10..1}; do
+  echo -n "${i}..."
+  sleep 1
+done
+echo ""
+
+RESPONSE=$(curl -s -v "${TEST_ENDPOINT}" \
+  -H "Authorization: Bearer ${TOKEN}" 2>&1)
+
+HTTP_STATUS=$(echo "$RESPONSE" | grep "< HTTP" | awk '{print $3}')
+RATE_REMAINING=$(echo "$RESPONSE" | grep -i "< X-RateLimit-Remaining:" | awk '{print $3}' | tr -d '\r')
+
+log_result "HTTP Status: ${HTTP_STATUS}"
+log_result "X-RateLimit-Remaining: ${RATE_REMAINING}"
+
+if [ "$HTTP_STATUS" = "200" ]; then
+  log_result "✓ 요청 성공 (토큰 리필됨)"
+  log_result "리필된 토큰: 10개 (refill-rate: 1 token/sec × 10 sec)"
+  log_result "남은 토큰: ${RATE_REMAINING} (10 - 1)"
+  TEST5_RESULT="success"
+else
+  log_result "✗ 요청 실패 (토큰 리필 안됨?)"
+  TEST5_RESULT="fail"
+fi
+log_result ""
+
+# ==============================================================================
+# Summary
+# ==============================================================================
+log_result "========================================"
+log_result "Test Summary"
+log_result "========================================"
+
+# 각 테스트 결과 출력
+if [ "$TEST0_RESULT" = "success" ]; then
+  log_result "✓ Test 0: 회원가입"
+else
+  log_result "✗ Test 0: 회원가입"
+fi
+
+if [ "$TEST1_RESULT" = "success" ]; then
+  log_result "✓ Test 1: JWT 토큰 획득"
+else
+  log_result "✗ Test 1: JWT 토큰 획득"
+fi
+
+if [ "$TEST2_RESULT" = "success" ]; then
+  log_result "✓ Test 2: Rate Limit 헤더 확인"
+else
+  log_result "✗ Test 2: Rate Limit 헤더 확인"
+fi
+
+if [ "$TEST3_RESULT" = "success" ]; then
+  log_result "✓ Test 3: 10번 연속 요청 성공"
+elif [ "$TEST3_RESULT" = "partial_fail" ]; then
+  log_result "⚠ Test 3: 10번 연속 요청 일부 실패 (Test 2에서 토큰 1개 소진됨)"
+else
+  log_result "✗ Test 3: 10번 연속 요청 실패"
+fi
+
+if [ "$TEST4_RESULT" = "success" ]; then
+  log_result "✓ Test 4: 11번째 요청 429 응답"
+elif [ "$TEST4_RESULT" = "partial_fail" ]; then
+  log_result "⚠ Test 4: 429 응답 확인, 단 에러 코드 확인 실패"
+else
+  log_result "✗ Test 4: 11번째 요청 429 응답 실패"
+fi
+
+if [ "$TEST5_RESULT" = "success" ]; then
+  log_result "✓ Test 5: 토큰 리필 확인"
+else
+  log_result "✗ Test 5: 토큰 리필 확인 실패"
+fi
+
+log_result ""
+
+# 전체 테스트 성공 여부 판단
+TOTAL_SUCCESS=0
+TOTAL_PARTIAL=0
+TOTAL_FAIL=0
+
+for result in "$TEST0_RESULT" "$TEST1_RESULT" "$TEST2_RESULT" "$TEST3_RESULT" "$TEST4_RESULT" "$TEST5_RESULT"; do
+  if [ "$result" = "success" ]; then
+    ((TOTAL_SUCCESS++))
+  elif [ "$result" = "partial_fail" ]; then
+    ((TOTAL_PARTIAL++))
+  elif [ "$result" = "fail" ]; then
+    ((TOTAL_FAIL++))
+  fi
+done
+
+if [ $TOTAL_FAIL -eq 0 ] && [ $TOTAL_PARTIAL -eq 0 ]; then
+  log_result "🎉 모든 테스트 성공! Rate Limiting이 정상 동작합니다."
+elif [ $TOTAL_FAIL -eq 0 ]; then
+  log_result "⚠ 일부 테스트가 부분 성공했습니다. Rate Limiting 핵심 기능은 정상 동작합니다."
+else
+  log_result "❌ 일부 테스트가 실패했습니다. 로그를 확인하세요."
+fi
+
+log_result ""
+log_result "결과 파일: ${RESULT_FILE}"

--- a/gateway/src/main/java/com/high/gateway/config/RateLimitConfig.java
+++ b/gateway/src/main/java/com/high/gateway/config/RateLimitConfig.java
@@ -1,0 +1,29 @@
+package com.high.gateway.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Rate Limiting Configuration
+ *
+ * Token Bucket 알고리즘의 파라미터를 관리합니다.
+ */
+@Getter
+@Configuration
+public class RateLimitConfig {
+
+    /**
+     * 버킷 최대 용량 (tokens)
+     * 사용자가 한 번에 사용할 수 있는 최대 토큰 수
+     */
+    @Value("${rate-limit.max-tokens:100}")
+    private int maxTokens;
+
+    /**
+     * 토큰 리필 속도 (tokens/sec)
+     * 초당 버킷에 추가되는 토큰 수
+     */
+    @Value("${rate-limit.refill-rate:10}")
+    private int refillRate;
+}

--- a/gateway/src/main/java/com/high/gateway/exception/GatewayErrorCode.java
+++ b/gateway/src/main/java/com/high/gateway/exception/GatewayErrorCode.java
@@ -22,7 +22,10 @@ public enum GatewayErrorCode implements BaseErrorCode {
 
     // 91xx: Authorization Errors
     UNAUTHORIZED(9100, HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다"),
-    FORBIDDEN(9101, HttpStatus.FORBIDDEN, "접근 권한이 없습니다");
+    FORBIDDEN(9101, HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
+
+    // 92xx: Rate Limiting Errors
+    RATE_LIMIT_EXCEEDED(9200, HttpStatus.TOO_MANY_REQUESTS, "요청 한도를 초과했습니다");
 
     private final int code;
     private final HttpStatus status;

--- a/gateway/src/main/java/com/high/gateway/exception/GlobalExceptionHandler.java
+++ b/gateway/src/main/java/com/high/gateway/exception/GlobalExceptionHandler.java
@@ -39,9 +39,21 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
         HttpStatus status;
         int code;
         String message;
+        Integer retryAfter = null;
 
+        // RateLimitExceededException 특별 처리 (Retry-After 헤더 추가)
+        if (ex instanceof RateLimitExceededException) {
+            RateLimitExceededException rateLimitEx = (RateLimitExceededException) ex;
+            status = rateLimitEx.getBaseErrorCode().getStatus();
+            code = rateLimitEx.getBaseErrorCode().getCode();
+            message = rateLimitEx.getBaseErrorCode().getMessage();
+            retryAfter = rateLimitEx.getRetryAfter();
+
+            // Retry-After 헤더 추가
+            exchange.getResponse().getHeaders().add("Retry-After", String.valueOf(retryAfter));
+        }
         // CustomException 처리 (common-module 패턴)
-        if (ex instanceof CustomException) {
+        else if (ex instanceof CustomException) {
             CustomException customException = (CustomException) ex;
             status = customException.getBaseErrorCode().getStatus();
             code = customException.getBaseErrorCode().getCode();
@@ -53,7 +65,7 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
             message = "서버 내부 오류가 발생했습니다";
         }
 
-        return writeErrorResponse(exchange, status, code, message);
+        return writeErrorResponse(exchange, status, code, message, retryAfter);
     }
 
     /**
@@ -61,10 +73,11 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
      * {
      *   "success": false,
      *   "code": 9000,
-     *   "message": "유효하지 않은 토큰입니다"
+     *   "message": "유효하지 않은 토큰입니다",
+     *   "retryAfter": 1  // Rate Limit 에러인 경우에만
      * }
      */
-    private Mono<Void> writeErrorResponse(ServerWebExchange exchange, HttpStatus status, int code, String message) {
+    private Mono<Void> writeErrorResponse(ServerWebExchange exchange, HttpStatus status, int code, String message, Integer retryAfter) {
         exchange.getResponse().setStatusCode(status);
         exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
 
@@ -72,6 +85,11 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
         errorResponse.put("success", false);
         errorResponse.put("code", code);
         errorResponse.put("message", message);
+
+        // Rate Limit 에러인 경우 retryAfter 추가
+        if (retryAfter != null) {
+            errorResponse.put("retryAfter", retryAfter);
+        }
 
         try {
             byte[] bytes = objectMapper.writeValueAsBytes(errorResponse);

--- a/gateway/src/main/java/com/high/gateway/exception/RateLimitExceededException.java
+++ b/gateway/src/main/java/com/high/gateway/exception/RateLimitExceededException.java
@@ -1,0 +1,27 @@
+package com.high.gateway.exception;
+
+import com.library.module.exception.CustomException;
+import lombok.Getter;
+
+/**
+ * Rate Limit Exceeded Exception
+ *
+ * 사용자가 요청 한도를 초과했을 때 발생하는 예외입니다.
+ * 429 Too Many Requests 응답과 함께 Retry-After 헤더를 제공합니다.
+ */
+@Getter
+public class RateLimitExceededException extends CustomException {
+
+    /**
+     * 재시도까지 대기 시간 (초)
+     */
+    private final int retryAfter;
+
+    /**
+     * @param retryAfter 재시도까지 대기 시간 (초)
+     */
+    public RateLimitExceededException(int retryAfter) {
+        super(GatewayErrorCode.RATE_LIMIT_EXCEEDED);
+        this.retryAfter = retryAfter;
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/filter/JwtAuthenticationGlobalFilter.java
+++ b/gateway/src/main/java/com/high/gateway/filter/JwtAuthenticationGlobalFilter.java
@@ -56,13 +56,13 @@ public class JwtAuthenticationGlobalFilter implements GlobalFilter, Ordered {
         String token = extractToken(exchange.getRequest());
         if (token == null) {
             log.warn("Token not found in request: {}", path);
-            throw new UnauthorizedException(GatewayErrorCode.TOKEN_NOT_FOUND);
+            return Mono.error(new UnauthorizedException(GatewayErrorCode.TOKEN_NOT_FOUND));
         }
 
         // JWT 검증
         if (!jwtTokenValidator.validateToken(token)) {
             log.warn("Invalid token for path: {}", path);
-            throw new UnauthorizedException(GatewayErrorCode.INVALID_TOKEN);
+            return Mono.error(new UnauthorizedException(GatewayErrorCode.INVALID_TOKEN));
         }
 
         // 블랙리스트 확인 (비동기)

--- a/gateway/src/main/java/com/high/gateway/filter/RateLimitingGlobalFilter.java
+++ b/gateway/src/main/java/com/high/gateway/filter/RateLimitingGlobalFilter.java
@@ -1,0 +1,73 @@
+package com.high.gateway.filter;
+
+import com.high.gateway.config.RateLimitConfig;
+import com.high.gateway.exception.RateLimitExceededException;
+import com.high.gateway.service.TokenBucketService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Rate Limiting Global Filter
+ *
+ * Token Bucket 알고리즘을 사용하여 Rate Limiting을 적용합니다.
+ * 인증된 사용자는 User ID 기반, 비인증 사용자는 IP 기반으로 제한합니다.
+ * 서버 부하 방지를 위해 모든 요청에 적용됩니다.
+ */
+@Slf4j
+@Component
+@Order(2)  // JWT Filter (HIGHEST_PRECEDENCE) 다음에 실행
+@RequiredArgsConstructor
+public class RateLimitingGlobalFilter implements GlobalFilter {
+
+    private final TokenBucketService tokenBucketService;
+    private final RateLimitConfig rateLimitConfig;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        // Rate Limiting 키 결정: 인증된 사용자는 User ID, 비인증 사용자는 IP
+        String userId = exchange.getRequest().getHeaders().getFirst("X-User-Id");
+        String rateLimitKey;
+
+        if (userId != null) {
+            // 인증된 사용자: User ID 기반
+            rateLimitKey = userId;
+        } else {
+            // 비인증 사용자: IP 기반
+            String clientIp = exchange.getRequest().getRemoteAddress() != null
+                    ? exchange.getRequest().getRemoteAddress().getAddress().getHostAddress()
+                    : "unknown";
+            rateLimitKey = "ip:" + clientIp;
+        }
+
+        // 토큰 1개 소비 시도
+        return tokenBucketService.tryConsume(rateLimitKey, 1)
+                .flatMap(allowed -> {
+                    if (!allowed) {
+                        // Rate Limit 초과 - Retry-After 시간 계산
+                        int retryAfter = (int) Math.ceil(1.0 / rateLimitConfig.getRefillRate());
+                        log.warn("Rate limit exceeded for key: {}, retry after: {}s", rateLimitKey, retryAfter);
+                        throw new RateLimitExceededException(retryAfter);
+                    }
+
+                    // Rate Limit 헤더 추가 (Response 헤더에)
+                    return tokenBucketService.getRemainingTokens(rateLimitKey)
+                            .flatMap(remaining -> {
+                                // Response 헤더에 Rate Limit 정보 추가
+                                exchange.getResponse().getHeaders().add("X-RateLimit-Limit", String.valueOf(rateLimitConfig.getMaxTokens()));
+                                exchange.getResponse().getHeaders().add("X-RateLimit-Remaining", String.valueOf(remaining));
+
+                                log.debug("Rate limit check passed for key: {}, remaining: {}/{}",
+                                        rateLimitKey, remaining, rateLimitConfig.getMaxTokens());
+
+                                return chain.filter(exchange);
+                            });
+                });
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/service/TokenBucketService.java
+++ b/gateway/src/main/java/com/high/gateway/service/TokenBucketService.java
@@ -1,0 +1,134 @@
+package com.high.gateway.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.high.gateway.config.RateLimitConfig;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StreamUtils;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Token Bucket Rate Limiting Service
+ *
+ * Redis Lua Script를 실행하여 Token Bucket 알고리즘을 구현하고
+ * 분산 환경에서 원자적 연산을 보장합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenBucketService {
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+    private final RateLimitConfig rateLimitConfig;
+
+    private RedisScript<Long> tokenBucketScript;
+
+    /**
+     * 애플리케이션 시작 시 Lua 스크립트 로드
+     */
+    @PostConstruct
+    public void init() {
+        try {
+            Resource resource = new ClassPathResource("lua/token_bucket.lua");
+            String scriptContent = StreamUtils.copyToString(
+                    resource.getInputStream(),
+                    StandardCharsets.UTF_8
+            );
+            this.tokenBucketScript = RedisScript.of(scriptContent, Long.class);
+            log.info("Token bucket Lua script loaded successfully");
+        } catch (IOException e) {
+            log.error("Failed to load token bucket Lua script", e);
+            throw new RuntimeException("Failed to load token bucket Lua script", e);
+        }
+    }
+
+    /**
+     * 버킷에서 토큰 소비 시도
+     *
+     * @param userId 사용자 ID (Rate Limiting 키)
+     * @param tokens 소비할 토큰 수 (일반적으로 1)
+     * @return Mono<Boolean> - 토큰이 있어서 소비 성공 시 true, Rate Limit 초과 시 false
+     */
+    public Mono<Boolean> tryConsume(String userId, int tokens) {
+        String key = "rate_limit:user:" + userId;
+        long now = System.currentTimeMillis();
+
+        List<String> keys = Collections.singletonList(key);
+        List<String> args = Arrays.asList(
+                String.valueOf(rateLimitConfig.getMaxTokens()),     // max_tokens (100)
+                String.valueOf(rateLimitConfig.getRefillRate()),    // refill_rate (10)
+                String.valueOf(tokens),                             // requested_tokens (1)
+                String.valueOf(now)                                 // current_timestamp_millis
+        );
+
+        return reactiveRedisTemplate.execute(tokenBucketScript, keys, args)
+                .next()
+                .map(result -> {
+                    // 스크립트는 실패 시 -1, 성공 시 >= 0 (남은 토큰 수) 반환
+                    boolean allowed = result >= 0;
+                    if (!allowed) {
+                        log.warn("Rate limit exceeded for user: {}", userId);
+                    } else {
+                        log.debug("Rate limit check passed for user: {}, remaining tokens: {}", userId, result);
+                    }
+                    return allowed;
+                })
+                .onErrorResume(e -> {
+                    log.error("Error executing token bucket script for user: {}", userId, e);
+                    // Fail-closed: Redis 오류 시 안전을 위해 요청 거부
+                    return Mono.just(false);
+                })
+                .defaultIfEmpty(false);  // 결과 없으면 기본값 false
+    }
+
+    /**
+     * 사용자의 남은 토큰 수 조회
+     *
+     * 저장된 버킷 상태에 리필 로직을 적용하여 현재 토큰 수를 계산합니다.
+     *
+     * @param userId 사용자 ID (Rate Limiting 키)
+     * @return Mono<Integer> - 현재 사용 가능한 토큰 수
+     */
+    public Mono<Integer> getRemainingTokens(String userId) {
+        String key = "rate_limit:user:" + userId;
+
+        return reactiveRedisTemplate.opsForValue().get(key)
+                .map(json -> {
+                    try {
+                        // JSON 버킷 상태 파싱
+                        ObjectMapper mapper = new ObjectMapper();
+                        JsonNode node = mapper.readTree(json);
+                        int tokens = node.get("tokens").asInt();
+                        long lastRefill = node.get("lastRefillTimestamp").asLong();
+
+                        // 경과 시간 기반 리필된 토큰 계산
+                        long now = System.currentTimeMillis();
+                        long elapsedSeconds = (now - lastRefill) / 1000;
+                        int refilled = (int) Math.floor(elapsedSeconds * rateLimitConfig.getRefillRate());
+
+                        // 현재 토큰 수 반환 (최대값으로 제한)
+                        int currentTokens = Math.min(rateLimitConfig.getMaxTokens(), tokens + refilled);
+                        log.debug("Remaining tokens for user {}: {}", userId, currentTokens);
+                        return currentTokens;
+                    } catch (Exception e) {
+                        log.error("Error parsing bucket state for user: {}", userId, e);
+                        return rateLimitConfig.getMaxTokens();  // 오류 시 최대값 반환
+                    }
+                })
+                .defaultIfEmpty(rateLimitConfig.getMaxTokens())  // 빈 버킷 = 최대 용량
+                .onErrorReturn(rateLimitConfig.getMaxTokens());  // 오류 시 최대값 반환
+    }
+}

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -29,12 +29,10 @@ spring:
 
   cloud:
     gateway:
-      server:
-        webflux:
-          discovery:
-            locator:
-              enabled: true
-          routes:
+      discovery:
+        locator:
+          enabled: true
+      routes:
             # 1. User Service (8100) - Authentication base
             - id: user-service
               uri: lb://user-service
@@ -154,3 +152,10 @@ logging:
   level:
     org.springframework.cloud.gateway: DEBUG
     org.springframework.web: DEBUG
+    com.high.gateway.filter: DEBUG
+    com.high.gateway.service: DEBUG
+
+# Rate Limiting configuration (Token Bucket Algorithm)
+rate-limit:
+  max-tokens: 10         # 버킷 최대 용량 (tokens) - TEST ONLY
+  refill-rate: 1         # 초당 토큰 리필 속도 (tokens/sec) - TEST ONLY

--- a/gateway/src/main/resources/lua/token_bucket.lua
+++ b/gateway/src/main/resources/lua/token_bucket.lua
@@ -1,0 +1,55 @@
+-- Token Bucket Rate Limiting Algorithm
+-- Ensures atomic operations for distributed rate limiting
+
+-- KEYS[1]: Redis key for the bucket (e.g., rate_limit:user:{userId})
+-- ARGV[1]: max_tokens - Maximum bucket capacity (e.g., 100)
+-- ARGV[2]: refill_rate - Tokens added per second (e.g., 10)
+-- ARGV[3]: requested_tokens - Tokens to consume for this request (e.g., 1)
+-- ARGV[4]: current_timestamp_millis - Current time in milliseconds
+
+local key = KEYS[1]
+local max_tokens = tonumber(ARGV[1])
+local refill_rate = tonumber(ARGV[2])
+local requested = tonumber(ARGV[3])
+local now = tonumber(ARGV[4])
+
+-- Get current bucket state from Redis
+local bucket = redis.call('GET', key)
+local tokens = max_tokens
+local last_refill = now
+
+-- If bucket exists, parse current state
+if bucket then
+    local data = cjson.decode(bucket)
+    tokens = tonumber(data.tokens)
+    last_refill = tonumber(data.lastRefillTimestamp)
+
+    -- Calculate refilled tokens based on elapsed time
+    local elapsed_seconds = (now - last_refill) / 1000
+    local refilled = math.floor(elapsed_seconds * refill_rate)
+
+    -- Add refilled tokens, capped at max_tokens
+    tokens = math.min(max_tokens, tokens + refilled)
+
+    -- Update last refill time to now
+    last_refill = now
+end
+
+-- Try to consume the requested tokens
+if tokens >= requested then
+    -- Enough tokens available
+    tokens = tokens - requested
+
+    -- Save updated bucket state with TTL of 120 seconds
+    local new_bucket = cjson.encode({
+        tokens = tokens,
+        lastRefillTimestamp = last_refill
+    })
+    redis.call('SETEX', key, 120, new_bucket)
+
+    -- Return remaining tokens (success)
+    return tokens
+else
+    -- Not enough tokens available
+    return -1
+end

--- a/user/src/main/java/com/high/user/application/service/UserQueryService.java
+++ b/user/src/main/java/com/high/user/application/service/UserQueryService.java
@@ -1,0 +1,65 @@
+package com.high.user.application.service;
+
+import com.high.user.application.dto.response.UserResponse;
+import com.high.user.domain.entity.User;
+import com.high.user.domain.exception.UserNotFoundException;
+import com.high.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * User Query Service
+ *
+ * 사용자 조회 전용 서비스
+ * - 인증과 무관한 순수 조회 로직만 포함
+ * - CQRS 패턴의 Query 측면 담당
+ * - 모든 조회 메서드는 @Transactional(readOnly = true) 적용
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserQueryService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자 ID로 사용자 정보 조회 (읽기 전용)
+     *
+     * @param userId 조회할 사용자 ID (String 형태의 UUID)
+     * @return UserResponse 사용자 정보 응답 DTO
+     * @throws UserNotFoundException 사용자를 찾을 수 없거나 삭제된 경우
+     * @throws IllegalArgumentException userId가 유효하지 않은 UUID 형식인 경우
+     */
+    @Transactional(readOnly = true)
+    public UserResponse getUserById(String userId) {
+        UUID userUuid;
+
+        try {
+            userUuid = UUID.fromString(userId);
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid UUID format for userId: {}", userId);
+            throw new IllegalArgumentException("Invalid user ID format", e);
+        }
+
+        User user = userRepository.findByIdAndDeletedAtIsNull(userUuid)
+                .orElseThrow(() -> {
+                    log.warn("User not found or deleted: userId={}", userId);
+                    return new UserNotFoundException();
+                });
+
+        log.info("User info retrieved successfully: userId={}, email={}", user.getUserId(), user.getEmail());
+
+        return UserResponse.from(user);
+    }
+
+    /**
+     * 향후 확장 가능 메서드 예시:
+     * - getUsersByRole(UserRole role)
+     * - searchUsersByEmail(String emailPattern)
+     * - getUserProfile(UUID userId) - 주소, 전화번호 등 상세 정보 포함
+     */
+}

--- a/user/src/main/java/com/high/user/presentation/UserController.java
+++ b/user/src/main/java/com/high/user/presentation/UserController.java
@@ -5,6 +5,7 @@ import com.high.user.application.dto.request.SignupRequest;
 import com.high.user.application.dto.response.TokenResponse;
 import com.high.user.application.dto.response.UserResponse;
 import com.high.user.application.service.UserAuthService;
+import com.high.user.application.service.UserQueryService;
 import com.library.module.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserAuthService userAuthService;
+    private final UserQueryService userQueryService;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<UserResponse>> signup(
@@ -49,10 +51,12 @@ public class UserController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @RequestHeader("Authorization") String bearerToken) {
-        // SecurityContext에서 userId 추출
+        // JWT 인증 정보에서 userId 추출
+        // SecurityContext → Authentication → Principal(userId)
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String userId = authentication.getName();
 
+        // Bearer 토큰에서 실제 JWT 추출 ("Bearer " prefix 제거)
         String accessToken = bearerToken.substring(7);
 
         log.info("Logout request received: userId={}", userId);
@@ -60,5 +64,20 @@ public class UserController {
         userAuthService.logout(accessToken, userId);
 
         return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다."));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo() {
+        // JWT 인증 정보에서 userId 추출
+        // Gateway의 JwtAuthenticationGlobalFilter에서 검증된 정보
+        // SecurityContext → Authentication → Principal(userId)
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userId = authentication.getName();
+
+        log.info("Get my info request received: userId={}", userId);
+
+        UserResponse response = userQueryService.getUserById(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }


### PR DESCRIPTION
## Issue Number
- Closes #41
- Closes #18

## 📝 Description

Gateway에 Token Bucket 알고리즘 기반 Rate Limiting을 구현하여 사용자별 요청 한도를 제한하고 시스템 안정성을 확보했습니다.
User에 내 정보 조회 API를 구현했습니다.(간단하게 Rate Limiting을 테스트하기 위해)

**구현 내용:**

**1. Token Bucket 알고리즘**
- 버킷 용량: 100 tokens
- 리필 속도: 10 tokens/sec
- Redis Lua Script로 원자적 연산 보장 (Race Condition 방지)
- TTL 120초 자동 메모리 정리

**2. 모든 요청에 Rate Limiting 적용**
- 인증된 사용자: User ID 기반 (`rate_limit:user:{userId}`)
- 비인증 사용자: IP 기반 (`rate_limit:user:ip:{clientIp}`)
- 서버 부하 방지를 위해 제외 경로 없음
- 분산 환경에서 일관된 제한 적용

**3. Rate Limit 헤더 제공**
- `X-RateLimit-Limit`: 100 (최대 용량)
- `X-RateLimit-Remaining`: 현재 남은 토큰 수

**4. 429 에러 응답**
- HTTP Status: 429 Too Many Requests
- Error Code: 9200
- `Retry-After` 헤더: 재시도 대기 시간 (초)
- 응답 body에 `retryAfter` 필드 포함

**5. Filter 우선순위**
- `@Order(2)`: JWT Filter (`HIGHEST_PRECEDENCE`) 다음 실행
- JWT 인증 후 Rate Limiting 적용 (User ID 또는 IP 기반)

**6. User Service - 내 정보 조회 API (GET /me)**
- SecurityContext에서 인증 정보 추출 (JWT Filter가 설정)
- UserQueryService로 CQRS 패턴 적용 (읽기 전용 서비스)
- `@Transactional(readOnly = true)`로 성능 최적화
- Soft Delete 확인 (`deletedAt IS NULL`)
- UserResponse DTO 반환

**구현 파일:**
```
gateway/src/main/resources/
  └─ lua/
     └─ token_bucket.lua                           # Token Bucket Lua Script
gateway/src/main/java/com/high/gateway/
  ├─ config/
  │  ├─ RateLimitConfig.java                       # max-tokens, refill-rate 설정
  │  └─ RedisConfig.java                           # ReactiveRedisTemplate Bean 등록
  ├─ service/
  │  └─ TokenBucketService.java                    # Lua Script 실행, 토큰 관리
  ├─ filter/
  │  └─ RateLimitingGlobalFilter.java              # Rate Limiting 필터 (Order: 2)
  └─ exception/
     ├─ RateLimitExceededException.java            # 429 예외 (retryAfter 포함)
     ├─ GatewayErrorCode.java                      # RATE_LIMIT_EXCEEDED(9200) 추가
     └─ GlobalExceptionHandler.java                # Retry-After 헤더 처리
gateway/src/main/resources/application.yaml        # rate-limit 설정, DEBUG 로깅
gateway/scripts/rate-limiting-test.sh              # 자동화 테스트 스크립트

user/src/main/java/com/high/user/
  ├─ application/service/
  │  ├─ UserQueryService.java                      # 조회 전용 서비스 (CQRS)
  │  └─ UserAuthService.java                       # getUserById 제거
  └─ presentation/
     └─ UserController.java                        # GET /me 엔드포인트
```

**Gateway 에러 코드 (9200 추가):**

| Code | Status | Message |
|------|--------|---------|
| 9200 | 429 | 요청 한도를 초과했습니다 |

## 🌐 Test Result

### 자동화 테스트 스크립트 사용 (권장)

Gateway Rate Limiting은 반복 요청 테스트가 필요하므로 자동화 스크립트를 제공합니다.

**스크립트 위치:**
```bash
gateway/scripts/rate-limiting-test.sh
```

**실행 방법:**
```bash
# 1. 스크립트 실행 권한 부여
chmod +x gateway/scripts/rate-limiting-test.sh

# 2. 스크립트 실행
cd gateway/scripts
./rate-limiting-test.sh
```

**스크립트 기능:**
- Test 0: 자동 회원가입 (랜덤 이메일 생성)
- Test 1: JWT 토큰 자동 획득 (로그인)
- Test 2: Rate Limit 헤더 확인 (X-RateLimit-Limit, X-RateLimit-Remaining)
- Test 3: 10번 연속 요청 (2초 대기 후 토큰 소진 테스트)
- Test 4: 11번째 요청 429 응답 확인 (Retry-After 헤더, 에러 코드 9200)
- Test 5: 10초 대기 후 토큰 리필 확인 (200 OK)
- 결과 파일 자동 생성: `gateway/scripts/rate-limiting-test-result-{timestamp}.txt`
- 동적 Summary 생성 (실제 테스트 결과 반영)

**참고:**
- 테스트 시 `application.yaml`의 rate-limit 설정을 `max-tokens: 10, refill-rate: 1`로 변경하여 빠른 테스트 가능
- 프로덕션 배포 전 반드시 `max-tokens: 100, refill-rate: 10`으로 복구 필요

<details>
<summary><strong>예상 출력 (펼쳐보기)</strong></summary>

```
========================================
Gateway Rate Limiting Test
========================================
결과 파일: gateway/scripts/rate-limiting-test-result-1733301234.txt

[Test 0] 회원가입
✓ 회원가입 성공
Email: test_1733301234@example.com

[Test 1] JWT 토큰 획득 (로그인)
✓ 토큰 획득 성공
Token: eyJhbGciOiJIUzI1NiJ...

[Test 2] 정상 요청 - Rate Limit 헤더 확인
HTTP Status: 200
X-RateLimit-Limit: 10
X-RateLimit-Remaining: 9
✓ 정상 요청 성공, Rate Limit 헤더 확인됨

[Test 3] 10번 연속 요청 - 토큰 소진
토큰 리필 방지를 위해 2초 대기...
요청 중...
..
성공: 10/10
실패: 0/10
✓ 10번 요청 모두 성공

[Test 4] 11번째 요청 - Rate Limit 초과 확인
HTTP Status: 429
Retry-After: 1
Response Body: {"code":9200,"retryAfter":1,"success":false,"message":"요청 한도를 초과했습니다"}
✓ 429 Too Many Requests 응답 확인
Error Code: 9200
Error Message: 요청 한도를 초과했습니다
Retry After (body): 1
✓ 올바른 에러 코드 (9200)

[Test 5] 토큰 리필 확인 (10초 대기)
대기 중...
10...9...8...7...6...5...4...3...2...1...
HTTP Status: 200
X-RateLimit-Remaining: 9
✓ 요청 성공 (토큰 리필됨)
리필된 토큰: 10개 (refill-rate: 1 token/sec × 10 sec)
남은 토큰: 9 (10 - 1)

========================================
Test Summary
========================================
✓ Test 0: 회원가입
✓ Test 1: JWT 토큰 획득
✓ Test 2: Rate Limit 헤더 확인
✓ Test 3: 10번 연속 요청 성공
✓ Test 4: 11번째 요청 429 응답
✓ Test 5: 토큰 리필 확인

🎉 모든 테스트 성공! Rate Limiting이 정상 동작합니다.

결과 파일: gateway/scripts/rate-limiting-test-result-1733301234.txt
```

</details>

<details>
<summary><strong>수동 테스트 방법 (curl + bash loop)</strong></summary>

자동화 스크립트를 사용할 수 없는 경우:

```bash
# 1. JWT 토큰 획득
TOKEN=$(curl -s -X POST http://localhost:8000/api/v1/users/login \
  -H "Content-Type: application/json" \
  -d '{"email":"testuser001@example.com","password":"password123@"}' \
  | jq -r '.data.accessToken')

# 2. 정상 요청 (1st - 헤더 확인)
curl -i http://localhost:8000/api/v1/users/me \
  -H "Authorization: Bearer $TOKEN"

# 예상 결과:
# HTTP/1.1 200 OK
# X-RateLimit-Limit: 100
# X-RateLimit-Remaining: 99

# 3. 100번 연속 요청
for i in {1..100}; do
  curl -s http://localhost:8000/api/v1/users/me \
    -H "Authorization: Bearer $TOKEN" -o /dev/null
done

# 4. 101번째 요청 (Rate Limit 초과)
curl -i http://localhost:8000/api/v1/users/me \
  -H "Authorization: Bearer $TOKEN"

# 예상 결과:
# HTTP/1.1 429 Too Many Requests
# Retry-After: 1
# { "success": false, "code": 9200, "message": "요청 한도를 초과했습니다", "retryAfter": 1 }

# 5. 10초 대기 후 재요청 (토큰 리필 확인)
sleep 10
curl -i http://localhost:8000/api/v1/users/me \
  -H "Authorization: Bearer $TOKEN"

# 예상 결과:
# HTTP/1.1 200 OK
# X-RateLimit-Limit: 100
# X-RateLimit-Remaining: 99 (100개 리필됨)
```

**대체 테스트 방법:**
- JMeter: Thread Group 200 users, 1 req/sec, 60초 실행
- Postman Runner: Collection 100회 반복 실행

</details>

## 🔎 To Reviewer

1. **유저 자기 정보 조회** 기능에 문제 없는지 검토 부탁드립니다.
2. **IP 인식 실패 처리**: 현재 IP를 가져오지 못한 대상은 모두 `unknown`(하나의 대상으로 서버가 인식)으로 처리되어, IP가 인식되지 못한 여러 사용자들의 요청 빈도가 제한될 수 있습니다. 마땅한 방법을 찾지 못했습니다.
3. **TTL** 연장했습니다. 저도 까먹을 수 있으니 마지막에 *TTL 1시간/7일로 변경하기*