### PR TITLE
feat: [orchestration] saga 로직 개발 및 kafka 이벤트 발행 

### DIFF
--- a/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
@@ -1,9 +1,12 @@
 package com.high.orchestration.application;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.high.orchestration.application.dto.internal.request.ClearCartCommandRequest;
 import com.high.orchestration.application.dto.internal.request.OrderCreateCommandRequest;
+import com.high.orchestration.application.dto.internal.request.PaymentCreateCommandRequest;
 import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
 import com.high.orchestration.application.dto.request.OrderCreateRequest;
+import com.high.orchestration.application.exception.FailedToInitializationException;
+import com.high.orchestration.application.exception.FailedToStartSagaException;
 import com.high.orchestration.application.exception.SagaStateNotFoundException;
 import com.high.orchestration.application.port.EventPublisher;
 import com.high.orchestration.domain.entity.SagaState;
@@ -22,8 +25,32 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderCreateSagaService {
 
     private final SagaStateRepository sagaStateRepository;
-    private final ObjectMapper objectMapper;
     private final EventPublisher publisher;
+
+    private SagaState initSagaState(
+        UUID sagaId,
+        UUID orderId,
+        SagaType sagaType,
+        CurrentStep currentStep,
+        String payload
+    ) {
+        try {
+            SagaState sagaState = SagaState.create(
+                sagaId,
+                orderId,
+                sagaType,
+                currentStep,
+                payload,
+                null
+            );
+           return sagaStateRepository.save(sagaState);
+
+        } catch ( Exception e ) {
+            log.error("[OrderCreateSagaService] SagaState initialization failed", e);
+            throw new FailedToInitializationException();
+        }
+    }
+
 
     @Transactional
     public void startOrderCreateStage(OrderCreateRequest orderCreateRequest, UUID ordererId) {
@@ -32,39 +59,36 @@ public class OrderCreateSagaService {
         UUID sagaId = UUID.randomUUID();
 
         OrderCreateCommandRequest orderCreateCommandRequest = OrderCreateCommandRequest.from(null, sagaId, ordererId, orderCreateRequest);
+
+        SagaState sagaState = initSagaState(
+            sagaId,
+            orderCreateCommandRequest.orderId(),
+            SagaType.ORDER_CREATE,
+            CurrentStep.ORDER_CREATE_VALIDATE,
+            orderCreateCommandRequest.toString()
+        );
+
+        log.info("[SagaService - startOrderCreateStage] - Saga Started : sagaId={}",
+            sagaId);
+
         try {
-            SagaState sagaState = SagaState.create(
-                orderCreateCommandRequest.sagaId(),
-                orderCreateCommandRequest.orderId(),
-                SagaType.ORDER_CREATE,
-                CurrentStep.ORDER_CREATE_VALIDATE,
-                objectMapper.writeValueAsString(orderCreateCommandRequest),
-                null
-            );
-
-            sagaStateRepository.save(sagaState);
-            System.out.println("받은 데이터 : " + objectMapper.writeValueAsString(
-                orderCreateCommandRequest));
-            log.info("[SagaService - startOrderCreateStage] - Saga Started : sagaId={}",
-                sagaId);
-
             publisher.publishOrderCreateCommand("order-create-request", orderCreateCommandRequest);
-
 
         } catch (Exception e) {
             log.info("Saga 시작 실패, 주문 생성 요청 전송 실패");
-            //exception 만들기
-            //kafka 발핼
+            sagaState.recordError(e.getMessage());
+            sagaStateRepository.save(sagaState);
+            throw new FailedToStartSagaException();
         }
         log.info("주문 생성 saga 시작 성공");
     }
 
     @Transactional
-    public void handlerOrderCreateSuccess(StockDeductionCommandRequest message) {
-        UUID sagaId = message.sagaId();
-
+    public void handlerOrderCreateSuccess(StockDeductionCommandRequest request) {
+        log.info("[OrderCreateSagaService] handlerOrderCreateSuccess - 주문생성완료 후 handler 유입 성공");
+        UUID sagaId = request.sagaId();
+        SagaState sagaState = getSagaState(sagaId);
         try {
-            SagaState sagaState =getSagaState(sagaId);
 
             if(sagaState.getCurrentStep().isAfter(CurrentStep.ORDER_CREATE_VALIDATE)) {
                 log.warn("[Idempotency] 이미 처리된 이벤트: sagaId={}, currentStep={}",
@@ -73,27 +97,94 @@ public class OrderCreateSagaService {
             }
 
             sagaState.updateSagaState(
-                message.orderId(),
                 null,
                 CurrentStep.ORDER_CREATE_STOCK,
-                message.toString()
+                request.toString()
             );
 
             SagaState updatedState = sagaStateRepository.save(sagaState);
 
             log.info("[OrderCreateSagaService] handlerOrderCreateSuccess : saga 상태 업데이트 - sagaId={}, orderId={}", updatedState.getSagaId(), updatedState.getOrderId());
 
-            publisher.publishStockDeductionCommand("stock-deduction-request", message);
+            publisher.publishStockDeductionCommand("stock-deduction-request", request);
             log.info("[OrderCreateSagaService] handlerOrderCreateSuccess : 재고차감 명령 발행 성공 ");
 
         } catch (Exception e) {
             log.error("[OrderCreateSagaService] handlerOrderCreateSuccess : 주문 생성 handler처리 실패");
+            sagaState.recordError(e.getMessage());
+            sagaStateRepository.save(sagaState);
+
+        }
+    }
+
+    @Transactional
+    public void handlerStockDeductionSuccess(PaymentCreateCommandRequest request) {
+        log.info("[OrderCreateSagaService] handlerStockDeductionSuccess - 재고차감 완료 후 handler 유입 성공");
+        UUID sagaId = request.sagaId();
+        SagaState sagaState = getSagaState(sagaId);
+
+        try {
+            if (sagaState.getCurrentStep().isAfter(CurrentStep.ORDER_CREATE_STOCK)) {
+                log.warn("[Idempotency] 이미 처리된 이벤트: sagaId={}, currentStep={}",
+                    sagaId, sagaState.getCurrentStep());
+                return;
+            }
+            sagaState.updateSagaState(
+                null,
+                CurrentStep.ORDER_CREATE_PAYMENT,
+                request.toString()
+            );
+            SagaState updatedState = sagaStateRepository.save(sagaState);
+
+            log.info("[OrderCreateSagaService] handlerStockDeductionSuccess : saga 상태 업데이트 - sagaId={}, orderId={}", updatedState.getSagaId(), updatedState.getOrderId());
+            publisher.publishPaymentCreateCommand("payment-create-request", request);
+            log.info("[OrderCreateSagaService] handlerStockDeductionSuccess : 결제 생성 명령 성공");
+
+        } catch (Exception e) {
+            log.error("[OrderCreateSagaService] handlerStockDeductionSuccess : 재고 차감 handler처리 실패");
+            sagaState.recordError(e.getMessage());
+            sagaStateRepository.save(sagaState);
+
+
+        }
+    }
+
+    @Transactional
+    public void handlerPaymentCreateSuccess(ClearCartCommandRequest request) {
+        log.info("[OrderCreateSagaService] handlerPaymentCreateSuccess - 결제생성 완료 후 handler 유입 성공");
+        UUID sagaId = request.sagaId();
+        SagaState sagaState = getSagaState(sagaId);
+
+        try {
+            if (sagaState.getCurrentStep().isAfter(CurrentStep.ORDER_CREATE_PAYMENT)) {
+                log.warn("[Idempotency] 이미 처리된 이벤트: sagaId={}, currentStep={}",
+                    sagaId, sagaState.getCurrentStep());
+                return;
+            }
+            sagaState.updateSagaState(
+                null,
+                null,
+                request.toString()
+            );
+            sagaStateRepository.save(sagaState);
+
+            publisher.publishClearCartCommand("cart-clear-request", request);
+            sagaState.updateCurrentStep(CurrentStep.ORDER_CREATE_COMPLETE);
+            sagaStateRepository.save(sagaState);
+
+            log.info("[OrderCreateSagaService] handlerPaymentCreateSuccess : 장바구니 비우기 명령 성공 - Saga 끝");
+
+        } catch (Exception e) {
+            log.error("[OrderCreateSagaService] handlerPaymentCreateSuccess : 결제 요청 handler처리 실패");
+            sagaState.recordError(e.getMessage());
+            sagaStateRepository.save(sagaState);
+
+
         }
     }
 
     public SagaState getSagaState(UUID sagaId) {
         return sagaStateRepository.findById(sagaId).orElseThrow(SagaStateNotFoundException::new);
     }
-
 
 }

--- a/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
@@ -2,7 +2,9 @@ package com.high.orchestration.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.orchestration.application.dto.internal.request.OrderCreateCommandRequest;
+import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
 import com.high.orchestration.application.dto.request.OrderCreateRequest;
+import com.high.orchestration.application.exception.SagaStateNotFoundException;
 import com.high.orchestration.application.port.EventPublisher;
 import com.high.orchestration.domain.entity.SagaState;
 import com.high.orchestration.domain.repository.SagaStateRepository;
@@ -56,4 +58,42 @@ public class OrderCreateSagaService {
         }
         log.info("주문 생성 saga 시작 성공");
     }
+
+    @Transactional
+    public void handlerOrderCreateSuccess(StockDeductionCommandRequest message) {
+        UUID sagaId = message.sagaId();
+
+        try {
+            SagaState sagaState =getSagaState(sagaId);
+
+            if(sagaState.getCurrentStep().isAfter(CurrentStep.ORDER_CREATE_VALIDATE)) {
+                log.warn("[Idempotency] 이미 처리된 이벤트: sagaId={}, currentStep={}",
+                    sagaId, sagaState.getCurrentStep());
+                return;
+            }
+
+            sagaState.updateSagaState(
+                message.orderId(),
+                null,
+                CurrentStep.ORDER_CREATE_STOCK,
+                message.toString()
+            );
+
+            SagaState updatedState = sagaStateRepository.save(sagaState);
+
+            log.info("[OrderCreateSagaService] handlerOrderCreateSuccess : saga 상태 업데이트 - sagaId={}, orderId={}", updatedState.getSagaId(), updatedState.getOrderId());
+
+            publisher.publishStockDeductionCommand("stock-deduction-request", message);
+            log.info("[OrderCreateSagaService] handlerOrderCreateSuccess : 재고차감 명령 발행 성공 ");
+
+        } catch (Exception e) {
+            log.error("[OrderCreateSagaService] handlerOrderCreateSuccess : 주문 생성 handler처리 실패");
+        }
+    }
+
+    public SagaState getSagaState(UUID sagaId) {
+        return sagaStateRepository.findById(sagaId).orElseThrow(SagaStateNotFoundException::new);
+    }
+
+
 }

--- a/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
@@ -127,6 +127,7 @@ public class OrderCreateSagaService {
         }
     }
 
+    //이 메서드는 수정될 예정
     @Transactional
     public void handlerPaymentCreateSuccess(ClearCartCommandRequest request) {
         log.info("[OrderCreateSagaService] handlerPaymentCreateSuccess - 결제생성 완료 후 handler 유입 성공");
@@ -141,6 +142,8 @@ public class OrderCreateSagaService {
             updateAndSaveSagaState(sagaState, null, request.toString());
 
             publisher.publishClearCartCommand("cart-clear-request", request);
+
+            //TODO: 종료 시점과 종료 처리 고민중...
             sagaState.updateCurrentStep(CurrentStep.ORDER_CREATE_COMPLETE);
             sagaStateRepository.save(sagaState);
 

--- a/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
@@ -76,8 +76,7 @@ public class OrderCreateSagaService {
 
         } catch (Exception e) {
             log.info("Saga 시작 실패, 주문 생성 요청 전송 실패");
-            sagaState.recordError(e.getMessage());
-            sagaStateRepository.save(sagaState);
+            recordSagaError(sagaState, e);
             throw new FailedToStartSagaException();
         }
         log.info("주문 생성 saga 시작 성공");
@@ -90,29 +89,18 @@ public class OrderCreateSagaService {
         SagaState sagaState = getSagaState(sagaId);
         try {
 
-            if(sagaState.getCurrentStep().isAfter(CurrentStep.ORDER_CREATE_VALIDATE)) {
-                log.warn("[Idempotency] 이미 처리된 이벤트: sagaId={}, currentStep={}",
-                    sagaId, sagaState.getCurrentStep());
+            if(checkIdempotency(sagaState, CurrentStep.ORDER_CREATE_VALIDATE)) {
                 return;
             }
 
-            sagaState.updateSagaState(
-                null,
-                CurrentStep.ORDER_CREATE_STOCK,
-                request.toString()
-            );
-
-            SagaState updatedState = sagaStateRepository.save(sagaState);
-
-            log.info("[OrderCreateSagaService] handlerOrderCreateSuccess : saga 상태 업데이트 - sagaId={}, orderId={}", updatedState.getSagaId(), updatedState.getOrderId());
+            updateAndSaveSagaState(sagaState, CurrentStep.ORDER_CREATE_STOCK, request.toString());
 
             publisher.publishStockDeductionCommand("stock-deduction-request", request);
             log.info("[OrderCreateSagaService] handlerOrderCreateSuccess : 재고차감 명령 발행 성공 ");
 
         } catch (Exception e) {
             log.error("[OrderCreateSagaService] handlerOrderCreateSuccess : 주문 생성 handler처리 실패");
-            sagaState.recordError(e.getMessage());
-            sagaStateRepository.save(sagaState);
+            recordSagaError(sagaState, e);
 
         }
     }
@@ -124,28 +112,18 @@ public class OrderCreateSagaService {
         SagaState sagaState = getSagaState(sagaId);
 
         try {
-            if (sagaState.getCurrentStep().isAfter(CurrentStep.ORDER_CREATE_STOCK)) {
-                log.warn("[Idempotency] 이미 처리된 이벤트: sagaId={}, currentStep={}",
-                    sagaId, sagaState.getCurrentStep());
+            if (checkIdempotency(sagaState, CurrentStep.ORDER_CREATE_STOCK)) {
                 return;
             }
-            sagaState.updateSagaState(
-                null,
-                CurrentStep.ORDER_CREATE_PAYMENT,
-                request.toString()
-            );
-            SagaState updatedState = sagaStateRepository.save(sagaState);
 
-            log.info("[OrderCreateSagaService] handlerStockDeductionSuccess : saga 상태 업데이트 - sagaId={}, orderId={}", updatedState.getSagaId(), updatedState.getOrderId());
+            updateAndSaveSagaState(sagaState, CurrentStep.ORDER_CREATE_PAYMENT, request.toString());
+
             publisher.publishPaymentCreateCommand("payment-create-request", request);
             log.info("[OrderCreateSagaService] handlerStockDeductionSuccess : 결제 생성 명령 성공");
 
         } catch (Exception e) {
             log.error("[OrderCreateSagaService] handlerStockDeductionSuccess : 재고 차감 handler처리 실패");
-            sagaState.recordError(e.getMessage());
-            sagaStateRepository.save(sagaState);
-
-
+            recordSagaError(sagaState, e);
         }
     }
 
@@ -156,17 +134,11 @@ public class OrderCreateSagaService {
         SagaState sagaState = getSagaState(sagaId);
 
         try {
-            if (sagaState.getCurrentStep().isAfter(CurrentStep.ORDER_CREATE_PAYMENT)) {
-                log.warn("[Idempotency] 이미 처리된 이벤트: sagaId={}, currentStep={}",
-                    sagaId, sagaState.getCurrentStep());
+            if (checkIdempotency(sagaState, CurrentStep.ORDER_CREATE_PAYMENT)) {
                 return;
             }
-            sagaState.updateSagaState(
-                null,
-                null,
-                request.toString()
-            );
-            sagaStateRepository.save(sagaState);
+
+            updateAndSaveSagaState(sagaState, null, request.toString());
 
             publisher.publishClearCartCommand("cart-clear-request", request);
             sagaState.updateCurrentStep(CurrentStep.ORDER_CREATE_COMPLETE);
@@ -176,9 +148,7 @@ public class OrderCreateSagaService {
 
         } catch (Exception e) {
             log.error("[OrderCreateSagaService] handlerPaymentCreateSuccess : 결제 요청 handler처리 실패");
-            sagaState.recordError(e.getMessage());
-            sagaStateRepository.save(sagaState);
-
+            recordSagaError(sagaState, e);
 
         }
     }
@@ -187,4 +157,26 @@ public class OrderCreateSagaService {
         return sagaStateRepository.findById(sagaId).orElseThrow(SagaStateNotFoundException::new);
     }
 
+    private boolean checkIdempotency(SagaState sagaState, CurrentStep expectedStep) {
+        if (sagaState.getCurrentStep().isAfter(expectedStep)) {
+            log.warn("[Idempotency] 이미 처리된 이벤트: sagaId={}, currentStep={}",
+                sagaState.getSagaId(), sagaState.getCurrentStep());
+            return true;
+        }
+        return false;
+    }
+
+    private void updateAndSaveSagaState(SagaState sagaState, CurrentStep nextStep, String payload) {
+        sagaState.updateSagaState(null, nextStep, payload);
+        SagaState updatedState = sagaStateRepository.save(sagaState);
+
+        log.info("[OrderCreateSagaService] saga 상태 업데이트 - sagaId={}, orderId={}, step={}",
+            updatedState.getSagaId(), updatedState.getOrderId(), nextStep);
+
+    }
+
+    private void recordSagaError(SagaState sagaState, Exception e) {
+        sagaState.recordError(e.getMessage());
+        sagaStateRepository.save(sagaState);
+    }
 }

--- a/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/OrderCreateSagaService.java
@@ -3,11 +3,11 @@ package com.high.orchestration.application;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.orchestration.application.dto.internal.request.OrderCreateCommandRequest;
 import com.high.orchestration.application.dto.request.OrderCreateRequest;
+import com.high.orchestration.application.port.EventPublisher;
 import com.high.orchestration.domain.entity.SagaState;
 import com.high.orchestration.domain.repository.SagaStateRepository;
 import com.high.orchestration.domain.vo.CurrentStep;
 import com.high.orchestration.domain.vo.SagaType;
-import com.high.orchestration.infrastructure.kafka.producer.KafkaEventPublisher;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +21,7 @@ public class OrderCreateSagaService {
 
     private final SagaStateRepository sagaStateRepository;
     private final ObjectMapper objectMapper;
-    private final KafkaEventPublisher publisher;
+    private final EventPublisher publisher;
 
     @Transactional
     public void startOrderCreateStage(OrderCreateRequest orderCreateRequest, UUID ordererId) {

--- a/orchestration/src/main/java/com/high/orchestration/application/dto/internal/request/ClearCartCommandRequest.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/dto/internal/request/ClearCartCommandRequest.java
@@ -1,0 +1,10 @@
+package com.high.orchestration.application.dto.internal.request;
+
+import java.util.UUID;
+
+public record ClearCartCommandRequest(
+    UUID sagaId,
+    UUID orderId
+) {
+
+}

--- a/orchestration/src/main/java/com/high/orchestration/application/dto/internal/request/PaymentCreateCommandRequest.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/dto/internal/request/PaymentCreateCommandRequest.java
@@ -1,0 +1,10 @@
+package com.high.orchestration.application.dto.internal.request;
+
+import java.util.UUID;
+
+public record PaymentCreateCommandRequest(
+    UUID sagaId,
+    UUID orderId
+) {
+
+}

--- a/orchestration/src/main/java/com/high/orchestration/application/dto/internal/request/StockDeductionCommandRequest.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/dto/internal/request/StockDeductionCommandRequest.java
@@ -1,0 +1,10 @@
+package com.high.orchestration.application.dto.internal.request;
+
+import java.util.UUID;
+
+public record StockDeductionCommandRequest(
+    UUID orderId,
+    UUID sagaId
+) {
+
+}

--- a/orchestration/src/main/java/com/high/orchestration/application/exception/FailedToInitializationException.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/exception/FailedToInitializationException.java
@@ -1,0 +1,11 @@
+package com.high.orchestration.application.exception;
+
+import com.high.orchestration.exception.OrchestrationErrorCode;
+import com.library.module.exception.CustomException;
+
+public class FailedToInitializationException extends CustomException {
+
+    public FailedToInitializationException() {
+        super(OrchestrationErrorCode.FAILED_TO_INITIALIZATION);
+    }
+}

--- a/orchestration/src/main/java/com/high/orchestration/application/exception/SagaStateNotFoundException.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/exception/SagaStateNotFoundException.java
@@ -1,0 +1,11 @@
+package com.high.orchestration.application.exception;
+
+import com.high.orchestration.exception.OrchestrationErrorCode;
+import com.library.module.exception.CustomException;
+
+public class SagaStateNotFoundException extends CustomException {
+
+    public SagaStateNotFoundException() {
+        super(OrchestrationErrorCode.SAGA_STATE_NOT_FOUND);
+    }
+}

--- a/orchestration/src/main/java/com/high/orchestration/application/port/EventPublisher.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/port/EventPublisher.java
@@ -1,0 +1,10 @@
+package com.high.orchestration.application.port;
+
+import com.high.orchestration.application.dto.internal.request.OrderCreateCommandRequest;
+
+public interface EventPublisher {
+
+    void publishOrderCreateCommand(String topic,
+        OrderCreateCommandRequest orderCreateCommandRequest);
+
+}

--- a/orchestration/src/main/java/com/high/orchestration/application/port/EventPublisher.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/port/EventPublisher.java
@@ -1,10 +1,12 @@
 package com.high.orchestration.application.port;
 
 import com.high.orchestration.application.dto.internal.request.OrderCreateCommandRequest;
+import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
 
 public interface EventPublisher {
 
     void publishOrderCreateCommand(String topic,
         OrderCreateCommandRequest orderCreateCommandRequest);
 
+    void publishStockDeductionCommand(String topic, StockDeductionCommandRequest message);
 }

--- a/orchestration/src/main/java/com/high/orchestration/application/port/EventPublisher.java
+++ b/orchestration/src/main/java/com/high/orchestration/application/port/EventPublisher.java
@@ -1,6 +1,8 @@
 package com.high.orchestration.application.port;
 
+import com.high.orchestration.application.dto.internal.request.ClearCartCommandRequest;
 import com.high.orchestration.application.dto.internal.request.OrderCreateCommandRequest;
+import com.high.orchestration.application.dto.internal.request.PaymentCreateCommandRequest;
 import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
 
 public interface EventPublisher {
@@ -9,4 +11,8 @@ public interface EventPublisher {
         OrderCreateCommandRequest orderCreateCommandRequest);
 
     void publishStockDeductionCommand(String topic, StockDeductionCommandRequest message);
+
+    void publishPaymentCreateCommand(String s, PaymentCreateCommandRequest request);
+
+    void publishClearCartCommand(String s, ClearCartCommandRequest request);
 }

--- a/orchestration/src/main/java/com/high/orchestration/domain/entity/SagaState.java
+++ b/orchestration/src/main/java/com/high/orchestration/domain/entity/SagaState.java
@@ -70,16 +70,23 @@ public class SagaState extends BaseUpdateEntity {
     }
 
     public void updateSagaState(
-        UUID orderId,
         SagaStatus sagaStatus,
         CurrentStep currentStep,
         String payload
     ) {
-        this.orderId = orderId;
         this.sagaStatus = sagaStatus == null ? this.sagaStatus : sagaStatus;
         this.currentStep = currentStep == null ? this.currentStep : currentStep;
         this.payload = payload == null ? this.payload : payload;
 
+    }
+
+    public void updateCurrentStep(CurrentStep currentStep) {
+        this.currentStep = currentStep;
+    }
+
+    public void recordError(String errorMessage) {
+        this.errorMessage = errorMessage;
+        this.sagaStatus = SagaStatus.FAILED;
     }
 
 

--- a/orchestration/src/main/java/com/high/orchestration/domain/entity/SagaState.java
+++ b/orchestration/src/main/java/com/high/orchestration/domain/entity/SagaState.java
@@ -69,5 +69,18 @@ public class SagaState extends BaseUpdateEntity {
         );
     }
 
+    public void updateSagaState(
+        UUID orderId,
+        SagaStatus sagaStatus,
+        CurrentStep currentStep,
+        String payload
+    ) {
+        this.orderId = orderId;
+        this.sagaStatus = sagaStatus == null ? this.sagaStatus : sagaStatus;
+        this.currentStep = currentStep == null ? this.currentStep : currentStep;
+        this.payload = payload == null ? this.payload : payload;
+
+    }
+
 
 }

--- a/orchestration/src/main/java/com/high/orchestration/domain/repository/SagaStateRepository.java
+++ b/orchestration/src/main/java/com/high/orchestration/domain/repository/SagaStateRepository.java
@@ -1,7 +1,10 @@
 package com.high.orchestration.domain.repository;
 
 import com.high.orchestration.domain.entity.SagaState;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface SagaStateRepository {
     SagaState save(SagaState sagaState);
+    Optional<SagaState> findById(UUID sagaId);
 }

--- a/orchestration/src/main/java/com/high/orchestration/domain/vo/CurrentStep.java
+++ b/orchestration/src/main/java/com/high/orchestration/domain/vo/CurrentStep.java
@@ -5,25 +5,37 @@ import lombok.Getter;
 @Getter
 public enum CurrentStep {
 
-    ORDER_CREATE_VALIDATE("주문 생성 - 주문 처리"),
-    ORDER_CREATE_STOCK("주문 생성 - 재고 차감"),
-    ORDER_CREATE_PAYMENT("주문 생성 - 결제 처리"),
-    ORDER_CREATE_COMPLETE("주문 생성 - 완료"),
+    ORDER_CREATE_VALIDATE("주문 생성 - 주문 처리",1,SagaType.ORDER_CREATE),
+    ORDER_CREATE_STOCK("주문 생성 - 재고 차감",2,SagaType.ORDER_CREATE),
+    ORDER_CREATE_PAYMENT("주문 생성 - 결제 처리",3,SagaType.ORDER_CREATE),
+    ORDER_CREATE_COMPLETE("주문 생성 - 완료",4,SagaType.ORDER_CREATE),
 
-    ORDER_CANCEL_VALIDATE("주문 취소 - 주문 삭제"),
-    ORDER_CANCEL_STOCK_RESTORE("주문 취소- 재고 복원"),
-    ORDER_CANCEL_REFUND("주문 취소 - 결제 취소"),
-    ORDER_CANCEL_COMPLETE("주문 취소 - 완료"),
+    ORDER_CANCEL_VALIDATE("주문 취소 - 주문 삭제",1,SagaType.ORDER_CANCEL),
+    ORDER_CANCEL_STOCK_RESTORE("주문 취소- 재고 복원",2,SagaType.ORDER_CANCEL),
+    ORDER_CANCEL_REFUND("주문 취소 - 결제 취소",3,SagaType.ORDER_CANCEL),
+    ORDER_CANCEL_COMPLETE("주문 취소 - 완료",4,SagaType.ORDER_CANCEL),
 
-    REFUND_VALIDATE("환불 - 주문 환불 처리"),
-    REFUND_EXECUTE("환불 - 결제 환불 처리"),
-    REFUND_COMPLETE("환불 - 완료");
+    REFUND_VALIDATE("환불 - 주문 환불 처리",1,SagaType.ORDER_REFUND),
+    REFUND_EXECUTE("환불 - 결제 환불 처리",2,SagaType.ORDER_REFUND),
+    REFUND_COMPLETE("환불 - 완료",3,SagaType.ORDER_REFUND),;
 
 
 
     private final String description;
+    private final int seq;
+    private final SagaType sagaType;
 
-    CurrentStep(String description) {
+
+    CurrentStep(String description, int seq, SagaType sagaType) {
         this.description = description;
+        this.seq = seq;
+        this.sagaType = sagaType;
+    }
+
+    public boolean isAfter(CurrentStep step) {
+        if(!this.sagaType.equals(step.sagaType)) {
+            return false;
+        }
+        return this.seq > step.seq;
     }
 }

--- a/orchestration/src/main/java/com/high/orchestration/exception/OrchestrationErrorCode.java
+++ b/orchestration/src/main/java/com/high/orchestration/exception/OrchestrationErrorCode.java
@@ -10,9 +10,14 @@ import org.springframework.http.HttpStatus;
 public enum OrchestrationErrorCode implements BaseErrorCode {
 
     //응용 계층 예외
-    FAILED_TO_START_SAGA(8000, HttpStatus.BAD_REQUEST, "Saga를 시작에 실패하였습니다.");
+    FAILED_TO_START_SAGA(8000, HttpStatus.BAD_REQUEST, "Saga를 시작에 실패하였습니다."),
+    SAGA_STATE_NOT_FOUND(8001, HttpStatus.NOT_FOUND, "Saga State를 찾을 수 없습니다.")
+
 
     //도메인 계층 예외
+
+
+    ;
 
     private final int code;
     private final HttpStatus status;

--- a/orchestration/src/main/java/com/high/orchestration/exception/OrchestrationErrorCode.java
+++ b/orchestration/src/main/java/com/high/orchestration/exception/OrchestrationErrorCode.java
@@ -11,8 +11,8 @@ public enum OrchestrationErrorCode implements BaseErrorCode {
 
     //응용 계층 예외
     FAILED_TO_START_SAGA(8000, HttpStatus.BAD_REQUEST, "Saga를 시작에 실패하였습니다."),
-    SAGA_STATE_NOT_FOUND(8001, HttpStatus.NOT_FOUND, "Saga State를 찾을 수 없습니다.")
-
+    SAGA_STATE_NOT_FOUND(8001, HttpStatus.NOT_FOUND, "Saga State를 찾을 수 없습니다."),
+    FAILED_TO_INITIALIZATION(8002, HttpStatus.BAD_REQUEST, "Saga 테이블 생성에 실패하였습니다.")
 
     //도메인 계층 예외
 

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/adaptor/OrderCreateAdapter.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/adaptor/OrderCreateAdapter.java
@@ -1,0 +1,16 @@
+package com.high.orchestration.infrastructure.adaptor;
+
+import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
+import com.high.orchestration.infrastructure.kafka.dto.response.OrderCreateSuccessMessage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderCreateAdapter {
+
+    public StockDeductionCommandRequest toCommand(OrderCreateSuccessMessage message) {
+        return new StockDeductionCommandRequest(
+            message.orderId(),
+            message.sagaId()
+        );
+    }
+}

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/adaptor/OrderCreateAdapter.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/adaptor/OrderCreateAdapter.java
@@ -1,14 +1,32 @@
 package com.high.orchestration.infrastructure.adaptor;
 
+import com.high.orchestration.application.dto.internal.request.ClearCartCommandRequest;
+import com.high.orchestration.application.dto.internal.request.PaymentCreateCommandRequest;
 import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
 import com.high.orchestration.infrastructure.kafka.dto.response.OrderCreateSuccessMessage;
+import com.high.orchestration.infrastructure.kafka.dto.response.PaymentCreateSuccessMessage;
+import com.high.orchestration.infrastructure.kafka.dto.response.StockDeductionSuccessMessage;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OrderCreateAdapter {
 
-    public StockDeductionCommandRequest toCommand(OrderCreateSuccessMessage message) {
+    public StockDeductionCommandRequest toStockDeductionCommand(OrderCreateSuccessMessage message) {
         return new StockDeductionCommandRequest(
+            message.orderId(),
+            message.sagaId()
+        );
+    }
+
+    public PaymentCreateCommandRequest toPaymentCreateCommand(StockDeductionSuccessMessage message) {
+        return new PaymentCreateCommandRequest(
+            message.orderId(),
+            message.sagaId()
+        );
+    }
+
+    public ClearCartCommandRequest toClearCartCommand(PaymentCreateSuccessMessage message) {
+        return new ClearCartCommandRequest(
             message.orderId(),
             message.sagaId()
         );

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/consumer/KafkaConsumer.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/consumer/KafkaConsumer.java
@@ -1,10 +1,16 @@
 package com.high.orchestration.infrastructure.kafka.consumer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.orchestration.application.OrderCreateSagaService;
+import com.high.orchestration.application.dto.internal.request.ClearCartCommandRequest;
+import com.high.orchestration.application.dto.internal.request.PaymentCreateCommandRequest;
 import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
 import com.high.orchestration.infrastructure.adaptor.OrderCreateAdapter;
 import com.high.orchestration.infrastructure.kafka.dto.response.OrderCreateSuccessMessage;
+import com.high.orchestration.infrastructure.kafka.dto.response.PaymentCreateSuccessMessage;
+import com.high.orchestration.infrastructure.kafka.dto.response.StockDeductionSuccessMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -25,15 +31,44 @@ public class KafkaConsumer {
 
             try {
                 OrderCreateSuccessMessage message = objectMapper.readValue(orderCreateSuccessMessage, OrderCreateSuccessMessage.class);
-                StockDeductionCommandRequest request = adapter.toCommand(message);
+                StockDeductionCommandRequest request = adapter.toStockDeductionCommand(message);
                 orderCreateSagaService.handlerOrderCreateSuccess(request);
             } catch (Exception e) {
                 log.error("[KafkaConsumer] orderCreateSuccess : 메시지 파싱 실패 : {}", orderCreateSuccessMessage, e);
             }
-
-            System.out.println("일단 메시지받기 완료");
         }
 
         //TODO: 주문 생성 실패 이벤트 구독 로직
+
+
+        @KafkaListener(topics = "stock-deduction-success")
+        public void stockDeductionSuccess(String stockDeductionSuccessMessage) {
+            log.info("[KafkaConsumer] stockDeductionSuccess :  stockDeductionSuccessMessage: {}", stockDeductionSuccessMessage);
+
+            try {
+                StockDeductionSuccessMessage message = objectMapper.readValue(stockDeductionSuccessMessage, StockDeductionSuccessMessage.class);
+                PaymentCreateCommandRequest request = adapter.toPaymentCreateCommand(message);
+                orderCreateSagaService.handlerStockDeductionSuccess(request);
+            } catch (Exception e) {
+                log.error("[KafkaConsumer] stockDeductionSuccess : 메시지 파싱 실패 : {}", stockDeductionSuccessMessage, e);
+            }
+
+        }
+
+        //TODO: 재고차감 실패 이벤트 구독 로직
+
+        @KafkaListener(topics = "payment-create-success")
+        public void paymentCreateSuccess(String paymentCreateSuccessMessage) {
+            log.info("[KafkaConsumer] paymentCreateSuccess  :  paymentCreateSuccessMessage: {}", paymentCreateSuccessMessage);
+
+            try {
+                PaymentCreateSuccessMessage message = objectMapper.readValue(paymentCreateSuccessMessage, PaymentCreateSuccessMessage.class);
+                ClearCartCommandRequest request = adapter.toClearCartCommand(message);
+                orderCreateSagaService.handlerPaymentCreateSuccess(request);
+            } catch (Exception e) {
+                log.error("[KafkaConsumer] paymentCreateSuccess : 메시지 파싱 실패 : {}", paymentCreateSuccessMessage, e);
+
+            }
+        }
 
 }

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/consumer/KafkaConsumer.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/consumer/KafkaConsumer.java
@@ -2,6 +2,8 @@ package com.high.orchestration.infrastructure.kafka.consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.orchestration.application.OrderCreateSagaService;
+import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
+import com.high.orchestration.infrastructure.adaptor.OrderCreateAdapter;
 import com.high.orchestration.infrastructure.kafka.dto.response.OrderCreateSuccessMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +17,7 @@ public class KafkaConsumer {
 
         private final OrderCreateSagaService orderCreateSagaService;
         private final ObjectMapper objectMapper;
+        private final OrderCreateAdapter adapter;
 
         @KafkaListener(topics = "order-success-create")
         public void orderCreateSuccess(String orderCreateSuccessMessage) {
@@ -22,10 +25,15 @@ public class KafkaConsumer {
 
             try {
                 OrderCreateSuccessMessage message = objectMapper.readValue(orderCreateSuccessMessage, OrderCreateSuccessMessage.class);
+                StockDeductionCommandRequest request = adapter.toCommand(message);
+                orderCreateSagaService.handlerOrderCreateSuccess(request);
             } catch (Exception e) {
                 log.error("[KafkaConsumer] orderCreateSuccess : 메시지 파싱 실패 : {}", orderCreateSuccessMessage, e);
             }
 
             System.out.println("일단 메시지받기 완료");
         }
+
+        //TODO: 주문 생성 실패 이벤트 구독 로직
+
 }

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/dto/response/OrderCreateSuccessMessage.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/dto/response/OrderCreateSuccessMessage.java
@@ -1,14 +1,10 @@
 package com.high.orchestration.infrastructure.kafka.dto.response;
 
-import java.util.List;
 import java.util.UUID;
 
 public record OrderCreateSuccessMessage(
     UUID orderId,
-    UUID sagaId,
-    UUID couponId,
-    UUID ordererId,
-    List<OrderItemCreateSuccessMessage> itemList
+    UUID sagaId
 ) {
 
 }

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/dto/response/OrderItemCreateSuccessMessage.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/dto/response/OrderItemCreateSuccessMessage.java
@@ -1,7 +1,7 @@
 package com.high.orchestration.infrastructure.kafka.dto.response;
 
 import java.util.UUID;
-
+//TODO: 필요없는 클래스인지 고려
 public record OrderItemCreateSuccessMessage(
     UUID productId,
     Integer quantity

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/dto/response/PaymentCreateSuccessMessage.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/dto/response/PaymentCreateSuccessMessage.java
@@ -1,0 +1,10 @@
+package com.high.orchestration.infrastructure.kafka.dto.response;
+
+import java.util.UUID;
+
+public record PaymentCreateSuccessMessage(
+    UUID sagaId,
+    UUID orderId
+) {
+
+}

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/dto/response/StockDeductionSuccessMessage.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/dto/response/StockDeductionSuccessMessage.java
@@ -1,0 +1,9 @@
+package com.high.orchestration.infrastructure.kafka.dto.response;
+
+import java.util.UUID;
+
+public record StockDeductionSuccessMessage(
+    UUID orderId,
+    UUID sagaId
+    ) {
+}

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/producer/KafkaEventPublisher.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/producer/KafkaEventPublisher.java
@@ -1,7 +1,9 @@
 package com.high.orchestration.infrastructure.kafka.producer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.high.orchestration.application.dto.internal.request.ClearCartCommandRequest;
 import com.high.orchestration.application.dto.internal.request.OrderCreateCommandRequest;
+import com.high.orchestration.application.dto.internal.request.PaymentCreateCommandRequest;
 import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
 import com.high.orchestration.application.port.EventPublisher;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +29,18 @@ public class KafkaEventPublisher implements EventPublisher {
     public void publishStockDeductionCommand(String topic, StockDeductionCommandRequest stockDeductionCommandRequest) {
         send(topic, stockDeductionCommandRequest);
         log.info("[KafkaEventPublisher] publicStockDeductionCommand 이벤트 발행 성공");
-        System.out.println("===========================일단 다됨 =====================");
 
+    }
+
+    @Override
+    public void publishPaymentCreateCommand(String topic, PaymentCreateCommandRequest paymentCreateCommandRequest) {
+        send(topic, paymentCreateCommandRequest);
+        log.info("[KafkaEventPublisher] publicPaymentCreateCommand 이벤트 발행 성공");
+    }
+
+    @Override
+    public void publishClearCartCommand(String topic, ClearCartCommandRequest clearCartCommandRequest) {
+        send(topic, clearCartCommandRequest);
     }
 
 

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/producer/KafkaEventPublisher.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/producer/KafkaEventPublisher.java
@@ -2,6 +2,7 @@ package com.high.orchestration.infrastructure.kafka.producer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.orchestration.application.dto.internal.request.OrderCreateCommandRequest;
+import com.high.orchestration.application.port.EventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -10,10 +11,22 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class KafkaEventPublisher {
+public class KafkaEventPublisher implements EventPublisher {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper;
+
+
+    private void send(String topic, Object messageObj) {
+        String json = toJson(messageObj);
+        kafkaTemplate.send(topic, json);
+        log.info("[KafkaEventPublisher] topic={}, message={}", topic, json);
+    }
+
+    public void publishOrderCreateCommand(String topic, OrderCreateCommandRequest orderCreateCommandRequest) {
+        send(topic, orderCreateCommandRequest);
+        log.info("[KafkaEventPublisher] publicOrderCreateCommand 이벤트 발행 성공");
+    }
 
     private String toJson(Object obj) {
         try {
@@ -26,16 +39,5 @@ public class KafkaEventPublisher {
             log.error("[KafkaEventPublisher] Kafka 메시지 JSON 변환 실패: {}", obj, e);
             throw new RuntimeException("Kafka 메시지 직렬화 오류", e);
         }
-    }
-
-    private void send(String topic, Object messageObj) {
-        String json = toJson(messageObj);
-        kafkaTemplate.send(topic, json);
-        log.info("[KafkaEventPublisher] topic={}, message={}", topic, json);
-    }
-
-    public void publishOrderCreateCommand(String topic, OrderCreateCommandRequest orderCreateCommandRequest) {
-        send(topic, orderCreateCommandRequest);
-        log.info("[KafkaEventPublisher] publicOrderCreateCommand 이벤트 발행 성공");
     }
 }

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/producer/KafkaEventPublisher.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/kafka/producer/KafkaEventPublisher.java
@@ -2,6 +2,7 @@ package com.high.orchestration.infrastructure.kafka.producer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.orchestration.application.dto.internal.request.OrderCreateCommandRequest;
+import com.high.orchestration.application.dto.internal.request.StockDeductionCommandRequest;
 import com.high.orchestration.application.port.EventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,15 +18,24 @@ public class KafkaEventPublisher implements EventPublisher {
     private final ObjectMapper objectMapper;
 
 
+    public void publishOrderCreateCommand(String topic, OrderCreateCommandRequest orderCreateCommandRequest) {
+        send(topic, orderCreateCommandRequest);
+        log.info("[KafkaEventPublisher] publicOrderCreateCommand 이벤트 발행 성공");
+    }
+
+    @Override
+    public void publishStockDeductionCommand(String topic, StockDeductionCommandRequest stockDeductionCommandRequest) {
+        send(topic, stockDeductionCommandRequest);
+        log.info("[KafkaEventPublisher] publicStockDeductionCommand 이벤트 발행 성공");
+        System.out.println("===========================일단 다됨 =====================");
+
+    }
+
+
     private void send(String topic, Object messageObj) {
         String json = toJson(messageObj);
         kafkaTemplate.send(topic, json);
         log.info("[KafkaEventPublisher] topic={}, message={}", topic, json);
-    }
-
-    public void publishOrderCreateCommand(String topic, OrderCreateCommandRequest orderCreateCommandRequest) {
-        send(topic, orderCreateCommandRequest);
-        log.info("[KafkaEventPublisher] publicOrderCreateCommand 이벤트 발행 성공");
     }
 
     private String toJson(Object obj) {

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/repository/SagaStateRepositoryAdapter.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/repository/SagaStateRepositoryAdapter.java
@@ -2,6 +2,8 @@ package com.high.orchestration.infrastructure.repository;
 
 import com.high.orchestration.domain.entity.SagaState;
 import com.high.orchestration.domain.repository.SagaStateRepository;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -14,5 +16,10 @@ public class SagaStateRepositoryAdapter implements SagaStateRepository {
     @Override
     public SagaState save(SagaState sagaState) {
         return jpaSagaStateRepository.save(sagaState);
+    }
+
+    @Override
+    public Optional<SagaState> findById(UUID sagaId) {
+        return jpaSagaStateRepository.findById(sagaId);
     }
 }

--- a/order/src/main/java/com/high/order/application/dto/internal/kafka/response/OrderItemSuccessResponse.java
+++ b/order/src/main/java/com/high/order/application/dto/internal/kafka/response/OrderItemSuccessResponse.java
@@ -3,6 +3,7 @@ package com.high.order.application.dto.internal.kafka.response;
 import com.high.order.domain.entity.OrderItem;
 import java.util.UUID;
 
+//TODO: 필요없는 클래스인지 고려
 public record OrderItemSuccessResponse(
     UUID productId,
     Integer quantity

--- a/order/src/main/java/com/high/order/application/dto/internal/kafka/response/OrderSuccessResponse.java
+++ b/order/src/main/java/com/high/order/application/dto/internal/kafka/response/OrderSuccessResponse.java
@@ -1,23 +1,17 @@
 package com.high.order.application.dto.internal.kafka.response;
 
 import com.high.order.domain.entity.Order;
-import java.util.List;
 import java.util.UUID;
 
 public record OrderSuccessResponse(
     UUID orderId,
-    UUID sagaId,
-    UUID couponId,
-    UUID ordererId,
-    List<OrderItemSuccessResponse> itemList
+    UUID sagaId
+
 ) {
-    public static OrderSuccessResponse of(Order order, UUID sagaId, UUID ordererId) {
+    public static OrderSuccessResponse of(Order order, UUID sagaId) {
         return new OrderSuccessResponse(
             order.getOrderId(),
-            sagaId,
-            order.getCouponId(),
-            ordererId,
-            order.getOrderItems().stream().map(OrderItemSuccessResponse::from).toList()
+            sagaId
         );
     }
 }

--- a/order/src/main/java/com/high/order/application/port/EventPublisher.java
+++ b/order/src/main/java/com/high/order/application/port/EventPublisher.java
@@ -1,0 +1,7 @@
+package com.high.order.application.port;
+
+import com.high.order.application.dto.internal.kafka.response.OrderSuccessResponse;
+
+public interface EventPublisher {
+    void sendOrderCreateSuccess(String topic, OrderSuccessResponse response);
+}

--- a/order/src/main/java/com/high/order/application/service/OrderServiceV2.java
+++ b/order/src/main/java/com/high/order/application/service/OrderServiceV2.java
@@ -92,7 +92,7 @@ public class OrderServiceV2 {
         );
         Order savedOrder = orderRepository.save(order);
 
-        return OrderSuccessResponse.of(order, request.sagaId(), request.ordererId());
+        return OrderSuccessResponse.of(order, request.sagaId());
     }
 
 

--- a/order/src/main/java/com/high/order/infrastructure/adapter/OrderCreateAdapter.java
+++ b/order/src/main/java/com/high/order/infrastructure/adapter/OrderCreateAdapter.java
@@ -1,4 +1,4 @@
-package com.high.order.infrastructure.adaptor;
+package com.high.order.infrastructure.adapter;
 
 import com.high.order.application.dto.internal.kafka.request.CreateOrderCommand;
 import com.high.order.application.dto.internal.kafka.request.CreateOrderItemCommand;

--- a/order/src/main/java/com/high/order/infrastructure/kafka/consumer/KafkaConsumer.java
+++ b/order/src/main/java/com/high/order/infrastructure/kafka/consumer/KafkaConsumer.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.order.application.dto.internal.kafka.request.CreateOrderCommand;
 import com.high.order.application.dto.internal.kafka.response.OrderSuccessResponse;
+import com.high.order.application.port.EventPublisher;
 import com.high.order.application.service.OrderServiceV2;
 import com.high.order.infrastructure.adaptor.OrderCreateAdapter;
 import com.high.order.infrastructure.exception.EmptyKafkaMessageException;
 import com.high.order.infrastructure.kafka.dto.response.OrderCreateRequestMessage;
-import com.high.order.infrastructure.kafka.producer.KafkaProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -22,7 +22,7 @@ public class KafkaConsumer {
     private final OrderServiceV2 orderService;
     private ObjectMapper objectMapper;
     private final OrderCreateAdapter adapter;
-    private final KafkaProducer kafkaProducer;
+    private final EventPublisher publisher;
 
     @KafkaListener(topics = "order-create-request")
     public void handleOrderCreateRequest(String message) {
@@ -48,7 +48,7 @@ public class KafkaConsumer {
             log.info("[KafkaConsumer] handleOrderCreateRequest : 주문 생성 로직 실행");
             OrderSuccessResponse response = orderService.createOrder(command);
 
-            kafkaProducer.sendOrderCreateSuccess("order-success-create", response);
+            publisher.sendOrderCreateSuccess("order-success-create", response);
             log.info("[KafkaConsumer] handlerOrderCreatRequest : 주문 생성 성공 메시지 생성");
         } catch (Exception e) {
 

--- a/order/src/main/java/com/high/order/infrastructure/kafka/consumer/KafkaConsumer.java
+++ b/order/src/main/java/com/high/order/infrastructure/kafka/consumer/KafkaConsumer.java
@@ -6,7 +6,7 @@ import com.high.order.application.dto.internal.kafka.request.CreateOrderCommand;
 import com.high.order.application.dto.internal.kafka.response.OrderSuccessResponse;
 import com.high.order.application.port.EventPublisher;
 import com.high.order.application.service.OrderServiceV2;
-import com.high.order.infrastructure.adaptor.OrderCreateAdapter;
+import com.high.order.infrastructure.adapter.OrderCreateAdapter;
 import com.high.order.infrastructure.exception.EmptyKafkaMessageException;
 import com.high.order.infrastructure.kafka.dto.response.OrderCreateRequestMessage;
 import lombok.RequiredArgsConstructor;

--- a/order/src/main/java/com/high/order/infrastructure/kafka/producer/KafkaEventPublisher.java
+++ b/order/src/main/java/com/high/order/infrastructure/kafka/producer/KafkaEventPublisher.java
@@ -3,6 +3,7 @@ package com.high.order.infrastructure.kafka.producer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.order.application.dto.internal.kafka.response.OrderSuccessResponse;
+import com.high.order.application.port.EventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class KafkaProducer {
+public class KafkaEventPublisher implements EventPublisher {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #55 
## 📝 Description
- saga 서비스 코드 리팩토링(로직 변화 x) 및 주문 saga 성공 로직 개발
- [orchestration] 재고차감 메시지 발행
- [orchestration] 결제요청 메시지 발행
- [orchestration] 장바구니 비우기 메시지 발행

## 🌐 Test Result

## 🔎 To Reviewer
- saga테이블 payload 데이터 저장 방식은 차후 변경될 예정입니다.(jsonb 고려 중 좀 더 생각해 볼 예정..)
- DB 트랜잭션과 메시지 발행의 원자성, 데이터 무결성 보장을 위해 추후 outbox 패턴을 적용할 예정입니다.(언젠가는 그럴 시간이 있겠지..)
- 멱등성 체크를 위해 CurrentStep enum에 시퀀스를 부여했습니다. 
- 토픽 이름과 dto 데이터는 다른 서비스와 소통하면서 변경될 수 있습니다.
