### PR TITLE
feat : Slack Api 연동 및 전송기능 구현

### DIFF
--- a/config/src/main/resources/config-repo/external-service.yml
+++ b/config/src/main/resources/config-repo/external-service.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: external-service
   datasource:
-    url: jdbc:mysql://mysql:3306/external_service?serverTimezone=UTC&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/external_service?serverTimezone=UTC&characterEncoding=UTF-8
     username: root
     password: admin1234
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/external/.gitignore
+++ b/external/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+secrets.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/external/build.gradle
+++ b/external/build.gradle
@@ -22,6 +22,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 ext {
@@ -29,6 +30,15 @@ ext {
 }
 
 dependencies {
+
+    // slack
+    implementation("com.slack.api:bolt:1.18.0")
+    implementation("com.slack.api:bolt-servlet:1.18.0")
+    implementation("com.slack.api:bolt-jetty:1.18.0")
+    implementation 'com.slack.api:slack-api-client'
+
+    implementation 'com.github.sharedeffort:common-module:v1.1.9'
+    implementation 'com.github.sharedeffort:common-jpa:v1.0.3'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/external/src/main/java/com/high/external/ExternalApplication.java
+++ b/external/src/main/java/com/high/external/ExternalApplication.java
@@ -2,8 +2,10 @@ package com.high.external;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = {"com.high.external", "com.library.module"})
 public class ExternalApplication {
 
 	public static void main(String[] args) {

--- a/external/src/main/java/com/high/external/application/dto/request/SendSlackMessageRequest.java
+++ b/external/src/main/java/com/high/external/application/dto/request/SendSlackMessageRequest.java
@@ -1,0 +1,9 @@
+package com.high.external.application.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class SendSlackMessageRequest {
+    private String recipientId;
+    private String message;
+}

--- a/external/src/main/java/com/high/external/application/dto/response/SlackRecordCreationDto.java
+++ b/external/src/main/java/com/high/external/application/dto/response/SlackRecordCreationDto.java
@@ -1,0 +1,31 @@
+package com.high.external.application.dto.response;
+
+import com.high.external.domain.model.SlackRecord;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class SlackRecordCreationDto {
+
+    private final UUID slackRecordId;
+    private final String recipientId;
+    private final String message;
+    private final LocalDateTime createdAt;
+    private final UUID createdBy;
+
+    public static SlackRecordCreationDto from(
+            SlackRecord slackRecord
+    ){
+        return SlackRecordCreationDto.builder()
+                .slackRecordId(slackRecord.getId())
+                .recipientId(slackRecord.getRecipientId())
+                .message(slackRecord.getMessage())
+                .createdAt(slackRecord.getCreatedAt())
+                .createdBy(slackRecord.getCreatedBy())
+                .build();
+    }
+}

--- a/external/src/main/java/com/high/external/application/dto/response/SlackRecordDeleteDto.java
+++ b/external/src/main/java/com/high/external/application/dto/response/SlackRecordDeleteDto.java
@@ -1,0 +1,28 @@
+package com.high.external.application.dto.response;
+
+
+import com.high.external.domain.model.SlackRecord;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class SlackRecordDeleteDto {
+
+    private final UUID slackRecordId;
+    private final LocalDateTime deletedAt;
+    private final UUID deletedBy;
+
+    public static SlackRecordDeleteDto from(
+            SlackRecord slackRecord
+    ){
+        return SlackRecordDeleteDto.builder()
+                .slackRecordId(slackRecord.getId())
+                .deletedAt(slackRecord.getDeletedAt())
+                .deletedBy(slackRecord.getDeletedBy())
+                .build();
+    }
+}

--- a/external/src/main/java/com/high/external/application/dto/response/SlackRecordDto.java
+++ b/external/src/main/java/com/high/external/application/dto/response/SlackRecordDto.java
@@ -1,0 +1,31 @@
+package com.high.external.application.dto.response;
+
+import com.high.external.domain.model.SlackRecord;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class SlackRecordDto {
+
+    private final UUID slackRecordId;
+    private final String recipientId;
+    private final String message;
+    private final LocalDateTime createdAt;
+    private final UUID createdBy;
+
+    public static SlackRecordDto from(
+            SlackRecord slackRecord
+    ){
+        return SlackRecordDto.builder()
+                .slackRecordId(slackRecord.getId())
+                .recipientId(slackRecord.getRecipientId())
+                .message(slackRecord.getMessage())
+                .createdAt(slackRecord.getCreatedAt())
+                .createdBy(slackRecord.getCreatedBy())
+                .build();
+    }
+}

--- a/external/src/main/java/com/high/external/application/service/SlackMessageServiceV1.java
+++ b/external/src/main/java/com/high/external/application/service/SlackMessageServiceV1.java
@@ -1,0 +1,26 @@
+package com.high.external.application.service;
+
+
+import com.high.external.domain.service.SlackNotifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SlackMessageServiceV1 {
+
+    private final SlackNotifier slackNotifier;
+    private final SlackRecordServiceV1 slackRecordServiceV1;
+
+    public String slackMessageSend(String targetSlackUserId, String message) {
+
+        String response;
+        try {
+            response = slackNotifier.notifyUser(targetSlackUserId, message);
+            slackRecordServiceV1.createSlackRecord(targetSlackUserId,message);
+        } catch (Exception e) {
+            throw new RuntimeException("Slack 알림 전송 및 기록 처리 중 오류 발생", e);
+        }
+        return response;
+    }
+}

--- a/external/src/main/java/com/high/external/application/service/SlackRecordServiceV1.java
+++ b/external/src/main/java/com/high/external/application/service/SlackRecordServiceV1.java
@@ -1,0 +1,93 @@
+package com.high.external.application.service;
+
+import com.high.external.application.dto.response.SlackRecordCreationDto;
+import com.high.external.application.dto.response.SlackRecordDeleteDto;
+import com.high.external.application.dto.response.SlackRecordDto;
+import com.high.external.domain.exception.SlackRecordNotFoundException;
+import com.high.external.domain.model.SlackRecord;
+import com.high.external.domain.repository.SlackRecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SlackRecordServiceV1 {
+
+    private final SlackRecordRepository repository;
+
+
+    /**
+     * <p>SlackRecord 생성</p>
+     *
+     * @param recipientId 수령인 식별자
+     * @param message     메세지 내용
+     */
+    public void createSlackRecord(String recipientId, String message) {
+        SlackRecord slackRecord = SlackRecord.create(recipientId, message);
+        repository.save(slackRecord);
+        SlackRecordCreationDto.from(slackRecord);
+    }
+
+
+    /**
+     * <p>특정 SlackRecord 조회</p>
+     *
+     * @param slackRecordId 식별자
+     * @return {@link SlackRecordDto}
+     */
+    public SlackRecordDto getSlackRecord(UUID slackRecordId) {
+        SlackRecord slackRecord = getRecord(slackRecordId);
+        return SlackRecordDto.from(slackRecord);
+    }
+
+    /**
+     * <p>특정 SlackRecord 리스트 조회</p>
+     *
+     * @param page      조회할 페이지 번호
+     * @param size      한 페이지당 SlackRecord의 개수
+     * @param sortBy    정렬 기준이 되는 필드 이름 (예: "createdAt")
+     * @param isAsc     오름차순 정렬 여부 (true: 오름차순, false: 내림차순)
+     * @return {@link SlackRecordDto}
+     */
+    public Page<SlackRecordDto> getSlackRecordList(int page, int size, String sortBy, boolean isAsc){
+        Pageable pageable = createPageable(page, size, sortBy, isAsc);
+        Page<SlackRecord> slackRecordPage = repository.findAll(pageable);
+        return slackRecordPage.map(SlackRecordDto::from);
+    }
+
+
+    /**
+     * <p>특정 SlackRecord soft delete</p>
+     *
+     * @param slackRecordId 식별자
+     * @param loginUserId    권한 확인을 위한 사용자 ID
+     * @return {@link SlackRecordDeleteDto}
+     */
+    @Transactional
+    public SlackRecordDeleteDto softDeleteSlackRecord(UUID slackRecordId, UUID loginUserId) {
+        SlackRecord slackRecord = getRecord(slackRecordId);
+//        slackRecord.softDelete(loginUserId);
+        return SlackRecordDeleteDto.from(slackRecord);
+    }
+
+
+
+
+    private SlackRecord getRecord(UUID slackRecordId) {
+        return repository.findById(slackRecordId).orElseThrow(SlackRecordNotFoundException::new);
+    }
+
+    private Pageable createPageable(int page, int size, String sortBy, boolean isAsc) {
+        int validatedSize = List.of(10, 30, 50).contains(size) ? size : 10;
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        return PageRequest.of(page - 1, validatedSize, Sort.by(direction, sortBy));
+    }
+}

--- a/external/src/main/java/com/high/external/domain/exception/SlackRecordNotFoundException.java
+++ b/external/src/main/java/com/high/external/domain/exception/SlackRecordNotFoundException.java
@@ -1,0 +1,10 @@
+package com.high.external.domain.exception;
+
+import com.high.external.exception.ExternalErrorCode;
+import com.library.module.exception.CustomException;
+
+public class SlackRecordNotFoundException extends CustomException {
+    public SlackRecordNotFoundException() {
+        super(ExternalErrorCode.SlACK_RECORD_NOT_FOUND);
+    }
+}

--- a/external/src/main/java/com/high/external/domain/model/SlackRecord.java
+++ b/external/src/main/java/com/high/external/domain/model/SlackRecord.java
@@ -1,0 +1,40 @@
+package com.high.external.domain.model;
+
+
+import com.library.jpa.common.entity.BaseDeleteEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_slack_records")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@AllArgsConstructor
+@SQLRestriction("deleted_at IS NULL")
+public class SlackRecord extends BaseDeleteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String recipientId;
+
+    @Column(nullable = false)
+    private String message;
+
+
+    public static SlackRecord create(String recipientId, String message){
+        return SlackRecord.builder()
+                .recipientId(recipientId)
+                .message(message)
+                .build();
+    }
+
+}

--- a/external/src/main/java/com/high/external/domain/repository/SlackRecordRepository.java
+++ b/external/src/main/java/com/high/external/domain/repository/SlackRecordRepository.java
@@ -1,0 +1,17 @@
+package com.high.external.domain.repository;
+
+import com.high.external.domain.model.SlackRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SlackRecordRepository {
+
+    void save(SlackRecord slackRecord);
+
+    Optional<SlackRecord> findById(UUID slackRecordId);
+
+    Page<SlackRecord> findAll(Pageable pageable);
+}

--- a/external/src/main/java/com/high/external/domain/service/SlackNotifier.java
+++ b/external/src/main/java/com/high/external/domain/service/SlackNotifier.java
@@ -1,0 +1,12 @@
+package com.high.external.domain.service;
+
+public interface SlackNotifier {
+
+    /**
+     * 특정 사용자에게 메시지를 보냅니다.
+     * @param slackUserId Slack User ID
+     * @param message 전송할 메시지 내용
+     */
+    String notifyUser(String slackUserId, String message);
+
+}

--- a/external/src/main/java/com/high/external/exception/ExternalErrorCode.java
+++ b/external/src/main/java/com/high/external/exception/ExternalErrorCode.java
@@ -1,0 +1,27 @@
+package com.high.external.exception;
+
+import com.library.module.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExternalErrorCode implements BaseErrorCode {
+
+
+    /**
+     * External - error 10000 번대
+     */
+
+    SlACK_RECORD_NOT_FOUND(10004, HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."),
+
+    SLACK_NOTIFICATION_FAILED(10500, HttpStatus.INTERNAL_SERVER_ERROR, "Slack DM 전송에 실패했습니다. (Slack 응답 오류)"),
+    SLACK_API_CALL_ERROR(10500, HttpStatus.INTERNAL_SERVER_ERROR, "Slack API 호출 중 예측하지 못한 오류가 발생했습니다.")
+
+    ;
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/external/src/main/java/com/high/external/infrastructure/client/slcak/SlackApiAdapter.java
+++ b/external/src/main/java/com/high/external/infrastructure/client/slcak/SlackApiAdapter.java
@@ -1,0 +1,48 @@
+package com.high.external.infrastructure.client.slcak;
+
+
+import com.high.external.domain.service.SlackNotifier;
+import com.high.external.infrastructure.exception.SlackApiCallErrorException;
+import com.high.external.infrastructure.exception.SlackApiNotificationFailException;
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SlackApiAdapter implements SlackNotifier {
+
+    @Value("${slack.token}")
+    private String slackToken;
+
+    @Override
+    public String notifyUser(String slackUserId, String message) {
+        // userId는 U로 시작하는 Slack User ID
+        try {
+            // Slack 클라이언트 초기화
+            Slack slack = Slack.getInstance();
+            MethodsClient methods = slack.methods(slackToken);
+
+            // 메시지 전송 요청 객체 생성 (chat.postMessage)
+            ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                    // channel 필드에 유저 ID를 사용하면 DM으로 전송됨
+                    .channel(slackUserId)
+                    .text(message)
+                    .build();
+
+            ChatPostMessageResponse response = methods.chatPostMessage(request);
+            if (response.isOk()) {
+                System.out.println("✅ Slack DM 전송 성공. User ID: " + slackUserId);
+                return message;
+            } else {
+                System.err.println("❌ Slack DM 전송 실패. Error: " + response.getError());
+                throw new SlackApiNotificationFailException();
+            }
+        } catch (Exception e) {
+            System.err.println("❌ Slack API 호출 중 오류 발생: " + e.getMessage());
+            throw new SlackApiCallErrorException();
+        }
+    }
+}

--- a/external/src/main/java/com/high/external/infrastructure/exception/SlackApiCallErrorException.java
+++ b/external/src/main/java/com/high/external/infrastructure/exception/SlackApiCallErrorException.java
@@ -1,0 +1,11 @@
+package com.high.external.infrastructure.exception;
+
+import com.high.external.exception.ExternalErrorCode;
+import com.library.module.exception.CustomException;
+
+public class SlackApiCallErrorException extends CustomException {
+    public SlackApiCallErrorException() {
+        super(ExternalErrorCode.SLACK_API_CALL_ERROR);
+    }
+
+}

--- a/external/src/main/java/com/high/external/infrastructure/exception/SlackApiNotificationFailException.java
+++ b/external/src/main/java/com/high/external/infrastructure/exception/SlackApiNotificationFailException.java
@@ -1,0 +1,10 @@
+package com.high.external.infrastructure.exception;
+
+import com.high.external.exception.ExternalErrorCode;
+import com.library.module.exception.CustomException;
+
+public class SlackApiNotificationFailException extends CustomException {
+    public SlackApiNotificationFailException(){
+        super(ExternalErrorCode.SLACK_NOTIFICATION_FAILED);
+    }
+}

--- a/external/src/main/java/com/high/external/infrastructure/persistence/SlackRecordJpaRepository.java
+++ b/external/src/main/java/com/high/external/infrastructure/persistence/SlackRecordJpaRepository.java
@@ -1,0 +1,9 @@
+package com.high.external.infrastructure.persistence;
+
+import com.high.external.domain.model.SlackRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SlackRecordJpaRepository extends JpaRepository<SlackRecord, UUID> {
+}

--- a/external/src/main/java/com/high/external/infrastructure/persistence/SlackRecordRepositoryImpl.java
+++ b/external/src/main/java/com/high/external/infrastructure/persistence/SlackRecordRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.high.external.infrastructure.persistence;
+
+
+import com.high.external.domain.model.SlackRecord;
+import com.high.external.domain.repository.SlackRecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Repository
+public class SlackRecordRepositoryImpl implements SlackRecordRepository {
+
+    private final SlackRecordJpaRepository slackRecordJpaRepository;
+
+
+    @Override
+    public void save(SlackRecord slackRecord) {
+        slackRecordJpaRepository.save(slackRecord);
+    }
+
+    @Override
+    public Optional<SlackRecord> findById(UUID slackRecordId) {
+        return slackRecordJpaRepository.findById(slackRecordId);
+    }
+
+    @Override
+    public Page<SlackRecord> findAll(Pageable pageable) {
+        return slackRecordJpaRepository.findAll(pageable);
+    }
+}

--- a/external/src/main/java/com/high/external/presentation/controller/SlackRecordControllerV1.java
+++ b/external/src/main/java/com/high/external/presentation/controller/SlackRecordControllerV1.java
@@ -1,0 +1,62 @@
+package com.high.external.presentation.controller;
+
+
+import com.high.external.application.dto.request.SendSlackMessageRequest;
+import com.high.external.application.dto.response.SlackRecordDeleteDto;
+import com.high.external.application.dto.response.SlackRecordDto;
+import com.high.external.application.service.SlackMessageServiceV1;
+import com.high.external.application.service.SlackRecordServiceV1;
+import com.library.jpa.response.PageResponse;
+import com.library.module.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/externals/slacks")
+@RequiredArgsConstructor
+public class SlackRecordControllerV1 {
+
+    private final SlackRecordServiceV1 serviceV1;
+    private final SlackMessageServiceV1 messageServiceV1;
+
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<SlackRecordDto>> getSlackRecord(
+            @PathVariable UUID id
+            ){
+        return ResponseEntity.ok(ApiResponse.success(serviceV1.getSlackRecord(id)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<SlackRecordDto>>> getSlackRecordList(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy,
+            @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc
+            ) {
+        Page<SlackRecordDto> slackRecordDtoPage = serviceV1.getSlackRecordList(page, size, sortBy, isAsc);
+        return ResponseEntity.ok(ApiResponse.success(PageResponse.fromPage(slackRecordDtoPage)));
+    }
+
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<SlackRecordDeleteDto>> softDeleteSlackRecord(
+            @PathVariable UUID id,
+            @RequestHeader("x-user-id") UUID userId
+            ){
+        SlackRecordDeleteDto response = serviceV1.softDeleteSlackRecord(id, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/message")
+    public ResponseEntity<ApiResponse<String>> sendSlackMessageTest(
+            @RequestBody SendSlackMessageRequest request
+            ){
+        String response = messageServiceV1.slackMessageSend(request.getRecipientId(), request.getMessage());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/external/src/main/resources/application.yaml
+++ b/external/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: external-service
   config:
-    import: "optional:configserver:"
+    import: "optional:configserver: , optional:classpath:secrets.yml"
   cloud:
     config:
       discovery:

--- a/external/src/main/resources/application.yaml
+++ b/external/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: external-service
   config:
-    import: "optional:configserver: , optional:classpath:secrets.yml"
+    import: "optional:configserver:"
   cloud:
     config:
       discovery:
@@ -24,3 +24,7 @@ eureka:
   instance:
     instance-id: external-service
     hostname: localhost
+
+
+slack:
+  token: ${SLACK_TOKEN}


### PR DESCRIPTION
SlackRecord 생성, 조회 구현

## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #58 

## 📝 Description
- Slack Api 연동
- Slack message 전송기능 구현
- message 전송기록 SlackRecord 저장 , 조회 기능 구현

## 🌐 Test Result
<details>
<summary>메세지 전송</summary>
<div markdown="1">
<img width="451" height="390" alt="스크린샷 2025-12-07 오후 9 17 09" src="https://github.com/user-attachments/assets/c0223989-1729-45ae-beaf-8a462989ed47" />
<img width="508" height="83" alt="스크린샷 2025-12-08 오전 9 54 32" src="https://github.com/user-attachments/assets/20b7cc0a-f60d-4c16-98e2-2cb6de237b4c" />

</div>
</details>

<details>
<summary>조회</summary>
<div markdown="1">
<img width="547" height="455" alt="스크린샷 2025-12-07 오후 9 17 19" src="https://github.com/user-attachments/assets/80ee81d0-4256-491a-b3ef-8fa67f9b45b8" />

</div>
</details>

## 🔎 To Reviewer
- 패키지 계층, 파일명이 팀 컨벤션에 맞는 지 확인해주세요
- Record 삭제 기능은 추후 감사 데이터 연동하면서 구현하겠습니다.
