### PR TITLE
feat: 쿠폰 사용 완료 처리 컨슈머 구현 및 internal 메서드 추가

### DIFF
--- a/coupon/coupon.sql
+++ b/coupon/coupon.sql
@@ -1,0 +1,55 @@
+-- =============================================
+-- 쿠폰 더미 데이터 (임시 테스트용) id, createBy 랜덤, UTC 시간으로 저장
+-- =============================================
+
+-- 1. 연말 세일 쿠폰
+-- 유효기간: 2025-12-31까지
+-- 총 수량: 1000개 (1인 1회 발급 가능)
+-- 할인율: 30%
+INSERT INTO p_coupon (
+    id, name, description, discount_rate, total_quantity,
+    created_at, updated_at, deleted_at, issue_start_at, issue_end_at, valid_until,
+    created_by, updated_by, deleted_by
+)
+VALUES (
+           UNHEX(REPLACE(UUID(),'-','')), -- id
+           '연말 세일 쿠폰',              -- name
+           '2025년 연말까지 사용 가능한 30% 할인 쿠폰 [전상품 적용]', -- description
+           30.00,                         -- discount_rate
+           1000,                           -- total_quantity
+           NOW(),                         -- created_at
+           NULL,                          -- updated_at
+           NULL,                          -- deleted_at
+           NOW(),                         -- issue_start_at
+           '2025-12-31 23:59:59',         -- issue_end_at
+           '2025-12-31 23:59:59',         -- valid_until
+           UNHEX(REPLACE(UUID(),'-','')), -- created_by (랜덤)
+           NULL,                          -- updated_by
+           NULL                           -- deleted_by
+       );
+
+-- 2. 깜짝 쿠폰 발급 이벤트
+-- 유효기간: 2025-12-10까지 (12-08 발급 종료)
+-- 총 수량: 500 (1인 1회 발급 가능)
+-- 할인율: 25%
+INSERT INTO p_coupon (
+    id, name, description, discount_rate, total_quantity,
+    created_at, updated_at, deleted_at, issue_start_at, issue_end_at, valid_until,
+    created_by, updated_by, deleted_by
+)
+VALUES (
+           UNHEX(REPLACE(UUID(),'-','')),
+           '깜짝 쿠폰',
+           '타임 어택 깜짝 쿠폰 [전상품 적용]',
+           25.00,
+           500,
+           NOW(),
+           NULL,
+           NULL,
+           NOW(),
+           '2025-12-08 23:59:59',
+           '2025-12-10 23:59:59',
+           UNHEX(REPLACE(UUID(),'-','')),
+           NULL,
+           NULL
+       );

--- a/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
@@ -107,7 +107,6 @@ public class CouponIssueService {
             throw new CouponNotValidPeriodException();
         }
 
-        // 4. 검증 통과 시 정보 반환
         return CouponValidationResponse.from(couponIssue);
     }
 

--- a/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
@@ -2,12 +2,15 @@ package com.high.coupon.application;
 
 import com.high.coupon.application.dto.response.CouponIssueResponse;
 import com.high.coupon.application.dto.response.CouponUseResponse;
+import com.high.coupon.application.dto.response.CouponValidationResponse;
 import com.high.coupon.application.dto.response.UserCouponResponse;
 import com.high.coupon.application.exception.CouponIssueNotFoundException;
 import com.high.coupon.application.exception.CouponOutOfStockException;
 import com.high.coupon.domain.entity.Coupon;
 import com.high.coupon.domain.entity.CouponIssue;
 import com.high.coupon.domain.exception.CouponAlreadyIssuedException;
+import com.high.coupon.domain.exception.CouponAlreadyUsedException;
+import com.high.coupon.domain.exception.CouponNotValidPeriodException;
 import com.high.coupon.domain.repository.CouponIssueRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -80,6 +83,32 @@ public class CouponIssueService {
         return issues.stream()
                 .map(UserCouponResponse::from)
                 .toList();
+    }
+
+    // 쿠폰 단건 유효성 검증용
+    public CouponValidationResponse validateCoupon(UUID couponIssueId, UUID userId) {
+
+        // 1. 조회
+        CouponIssue couponIssue = couponIssueRepository.findByIdAndUserId(couponIssueId, userId)
+                .orElseThrow(CouponIssueNotFoundException::new);
+
+        // 2. 사용 여부
+        if (Boolean.TRUE.equals(couponIssue.getIsUsed())) {
+            log.warn("[INTERNAL] Coupon-Issue-Service - 검증 실패: 이미 사용된 쿠폰 "
+                    + "- couponIssueId={}, usedAt={}", couponIssueId, couponIssue.getUsedAt());
+            throw new CouponAlreadyUsedException();
+        }
+
+        // 3. 유효 기간
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(couponIssue.getValidStartAt()) || now.isAfter(couponIssue.getValidEndAt())) {
+            log.warn("[INTERNAL] Coupon-Issue-Service - 검증 실패: 유효기간 불일치 "
+                    + "- couponIssueId={}, validEndAt={}, now={}", couponIssueId, couponIssue.getValidEndAt(), now);
+            throw new CouponNotValidPeriodException();
+        }
+
+        // 4. 검증 통과 시 정보 반환
+        return CouponValidationResponse.from(couponIssue);
     }
 
 

--- a/coupon/src/main/java/com/high/coupon/application/dto/response/CouponValidationResponse.java
+++ b/coupon/src/main/java/com/high/coupon/application/dto/response/CouponValidationResponse.java
@@ -1,0 +1,24 @@
+package com.high.coupon.application.dto.response;
+
+import com.high.coupon.domain.entity.CouponIssue;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * 쿠폰 검증 응답 DTO
+ */
+public record CouponValidationResponse(
+        UUID couponIssueId,
+        UUID couponId,
+        String couponName,
+        BigDecimal discountRate
+) {
+    public static CouponValidationResponse from(CouponIssue couponIssue){
+        return new CouponValidationResponse(
+                couponIssue.getId(),
+                couponIssue.getCoupon().getId(),
+                couponIssue.getCoupon().getName(),
+                couponIssue.getCoupon().getDiscountRate()
+        );
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/domain/repository/CouponIssueRepository.java
+++ b/coupon/src/main/java/com/high/coupon/domain/repository/CouponIssueRepository.java
@@ -14,4 +14,7 @@ public interface CouponIssueRepository {
 
     // 사용자 별 사용 가능 쿠폰만 조회
     List<CouponIssue> findAvailableByUserId(UUID userId);
+
+    // 쿠폰 단건 검증
+    Optional<CouponIssue> findByIdAndUserId(UUID couponIssueId, UUID userId);
 }

--- a/coupon/src/main/java/com/high/coupon/infrastructure/kafka/KafkaConfig.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/kafka/KafkaConfig.java
@@ -1,0 +1,62 @@
+package com.high.coupon.infrastructure.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    // todo 성공 결과 필요할까? (Producer 유무)
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory(){
+
+        /**
+         * Kafka ConsumerFactory 설정
+         * - Consumer 인스턴스를 생성하는 역할
+         * - KafkaListener가 실제로 메시지를 가져갈 때 필요한 설정들이 포함
+         */
+        // Kafka consumer 설정 값: KEY - VALUE String 기반으로 처리
+        Map<String, Object> props = new HashMap<>();
+        // Kafka 브로커 주소
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        // Consumer Group ID (같은 그룹이면 offset 공유)
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "coupon-service-group");
+        // Kafka 메시지 key 문자열로 역직렬화
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // Kafka 메시지 value 문자열로 역직렬화
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // 메시지 자동 커밋 방지 (비즈니스 성공 시 수동 commit 가능)
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    /**
+     * KafkaListener Container Factory 설정
+     * - 실제 @KafkaListener 메서드가 메시지를 소비하도록 컨테이너를 생성
+     * - ConsumerFactory를 기반으로 동작
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+
+        // 위에서 만든 consumerFactory 사용
+        factory.setConsumerFactory(consumerFactory());
+
+        return factory;
+    }
+
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/kafka/consumer/KafkaConsumer.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/kafka/consumer/KafkaConsumer.java
@@ -1,0 +1,59 @@
+package com.high.coupon.infrastructure.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.high.coupon.application.CouponIssueService;
+import com.high.coupon.infrastructure.kafka.dto.CouponUseRequestMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Service;
+
+/**
+ * Kafka 토픽 구독 Consumer - coupon-use-request 토픽 메세지를 받음
+ * todo 연동 테스트를 위해 컨슈머 기본 로직만 작성 (성공/실패 응답 로직 필요 여부 확인)
+ * 실패 시 로그만 남기고 ack 처리하도록 구현
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class KafkaConsumer {
+
+    private final CouponIssueService couponIssueService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 쿠폰 사용 전환 요청 메시지 구독
+     * - Infrastructure Layer
+     * - Kafka 토픽: coupon-use-request
+     * - Consumer Group: coupon-service-group
+     */
+    @KafkaListener(
+            topics = "coupon-use-request",
+            groupId = "coupon-service-group",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consumeCouponRequest(String message, Acknowledgment ack) {
+        log.info("[쿠폰 소비자] 수신 메시지: {}", message);
+        CouponUseRequestMessage dto = null;
+
+        try {
+            // JSON → DTO 역직렬화 (UUID 타입)
+            dto = objectMapper.readValue(message, CouponUseRequestMessage.class);
+            log.info("파싱 완료 sagaId: {}", dto.sagaId());
+
+            // Application Service 호출 (필요한 필드만 전달)
+            couponIssueService.useCoupon(dto.couponIssueId(), dto.userId());
+
+            // 처리 성공 시 알림
+            log.info("[쿠폰 소비자] 처리 성공 (sagaID: {}, couponIssueID: {})", dto.sagaId(), dto.couponIssueId());
+
+        } catch (Exception e) {
+            log.error("[쿠폰 소비자] 처리 실패 - 메시지 건너뜀. 내용: {}, 에러: {}", message, e.getMessage()); // todo: KafkaConfig DLQ 도입 필요
+
+        } finally {
+            // 성공하든 실패하든 무조건 커밋(Ack) 후 다음 메시지를 받을 준비
+            ack.acknowledge();
+        }
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/kafka/dto/CouponUseRequestMessage.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/kafka/dto/CouponUseRequestMessage.java
@@ -1,0 +1,16 @@
+package com.high.coupon.infrastructure.kafka.dto;
+
+import java.util.UUID;
+
+/**
+ * todo 필드 맞춰야함 (필요 필드 확인 필요)
+ * Kafka 메세지 역직렬화를 위한 DTO
+ * - Kafka에서 오는 json 메세지 구조와 일치 시켜야함
+ * ObjectMapper (String -> UUID 변환)
+ */
+public record CouponUseRequestMessage(
+        UUID couponIssueId, // 쿠폰 발급 ID
+        UUID userId,       // 쿠폰 사용자
+        UUID sagaId
+){
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/kafka/dto/CouponUseRequestMessage.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/kafka/dto/CouponUseRequestMessage.java
@@ -3,7 +3,6 @@ package com.high.coupon.infrastructure.kafka.dto;
 import java.util.UUID;
 
 /**
- * todo 필드 맞춰야함 (필요 필드 확인 필요)
  * Kafka 메세지 역직렬화를 위한 DTO
  * - Kafka에서 오는 json 메세지 구조와 일치 시켜야함
  * ObjectMapper (String -> UUID 변환)

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponIssueRepositoryAdaptor.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/CouponIssueRepositoryAdaptor.java
@@ -38,4 +38,9 @@ public class CouponIssueRepositoryAdaptor implements CouponIssueRepository {
     public List<CouponIssue> findAvailableByUserId(UUID userId){
         return jpaCouponIssueRepository.findAvailableByUserId(userId);
     }
+
+    @Override
+    public Optional<CouponIssue> findByIdAndUserId(UUID couponIssueId, UUID userId){
+        return jpaCouponIssueRepository.findByIdAndUserId(couponIssueId, userId);
+    }
 }

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponIssueRepository.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponIssueRepository.java
@@ -2,6 +2,7 @@ package com.high.coupon.infrastructure.persistence;
 
 import com.high.coupon.domain.entity.CouponIssue;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,6 +13,7 @@ public interface JpaCouponIssueRepository extends JpaRepository<CouponIssue, UUI
     boolean existsByCouponIdAndUserId(UUID couponId, UUID userId);
     long countByCouponId(UUID couponId);
 
+    // 리스트 조회
     @Query("""
     SELECT ci FROM CouponIssue ci
     JOIN FETCH ci.coupon
@@ -21,4 +23,18 @@ public interface JpaCouponIssueRepository extends JpaRepository<CouponIssue, UUI
       AND ci.validEndAt >= CURRENT_TIMESTAMP
 """)
     List<CouponIssue> findAvailableByUserId(@Param("userId") UUID userId);
+
+    // todo 쿼리 임시 확인 Optional<CouponIssue> findByIdAndUserId(UUID couponIssueId, UUID userId);
+
+    // 단건 검증 조회용
+    @Query("""
+        SELECT ci FROM CouponIssue ci
+        JOIN FETCH ci.coupon
+        WHERE ci.id = :couponIssueId
+          AND ci.userId = :userId
+    """)
+    Optional<CouponIssue> findByIdAndUserId(
+            @Param("couponIssueId") UUID couponIssueId,
+            @Param("userId") UUID userId
+    );
 }

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponIssueRepository.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/JpaCouponIssueRepository.java
@@ -24,8 +24,6 @@ public interface JpaCouponIssueRepository extends JpaRepository<CouponIssue, UUI
 """)
     List<CouponIssue> findAvailableByUserId(@Param("userId") UUID userId);
 
-    // todo 쿼리 임시 확인 Optional<CouponIssue> findByIdAndUserId(UUID couponIssueId, UUID userId);
-
     // 단건 검증 조회용
     @Query("""
         SELECT ci FROM CouponIssue ci

--- a/coupon/src/main/java/com/high/coupon/presentation/internal/CouponInternalController.java
+++ b/coupon/src/main/java/com/high/coupon/presentation/internal/CouponInternalController.java
@@ -2,6 +2,7 @@ package com.high.coupon.presentation.internal;
 
 import com.high.coupon.application.CouponIssueService;
 import com.high.coupon.application.dto.response.CouponUseResponse;
+import com.high.coupon.application.dto.response.CouponValidationResponse;
 import com.high.coupon.application.dto.response.UserCouponResponse;
 import com.library.module.response.ApiResponse;
 import java.util.List;
@@ -30,8 +31,21 @@ public class CouponInternalController {
      */
     @GetMapping
     public ApiResponse<List<UserCouponResponse>> getUserCoupons(@RequestParam UUID userId) {
-        List<UserCouponResponse> result = couponIssueService.getAvailableUserCoupons(userId);
-        return ApiResponse.success(result);
+        List<UserCouponResponse> response = couponIssueService.getAvailableUserCoupons(userId);
+        return ApiResponse.success(response);
+    }
+
+    /**
+     * 쿠폰 단건 유효성 검증 및 할인 정보
+     * GET /api/v1/internal/coupons/{couponIssueId}/validate?userId={userId}
+     */
+    @GetMapping("/{couponIssueId}/validate")
+    public ApiResponse<CouponValidationResponse> validateCoupon(
+            @PathVariable UUID couponIssueId,
+            @RequestParam UUID userId
+    ) {
+        CouponValidationResponse response = couponIssueService.validateCoupon(couponIssueId, userId);
+        return ApiResponse.success(response);
     }
 
     /**

--- a/coupon/src/test/java/com/high/coupon/kafka/KafkaConsumerTest.java
+++ b/coupon/src/test/java/com/high/coupon/kafka/KafkaConsumerTest.java
@@ -1,0 +1,100 @@
+package com.high.coupon.kafka;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.high.coupon.application.CouponIssueService;
+import com.high.coupon.infrastructure.kafka.consumer.KafkaConsumer;
+import com.high.coupon.infrastructure.kafka.dto.CouponUseRequestMessage;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+/**
+ * 임시 test: KafkaConsumer 작동 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+public class KafkaConsumerTest {
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private CouponIssueService couponIssueService;
+
+    @InjectMocks
+    private KafkaConsumer kafkaConsumer;
+
+    @Test
+    @DisplayName("성공: 정상적인 메시지가 오면 서비스 로직을 수행하고 Ack 처리")
+    void testConsumeCouponRequest_Success() throws Exception {
+        // given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID sagaId = UUID.randomUUID();
+        CouponUseRequestMessage request = new CouponUseRequestMessage(couponId, userId, sagaId);
+
+        String jsonMessage = objectMapper.writeValueAsString(request);
+
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        // when
+        kafkaConsumer.consumeCouponRequest(jsonMessage, ack);
+
+        // then
+        verify(couponIssueService, times(1)).useCoupon(couponId, userId);
+        verify(ack, times(1)).acknowledge();
+    }
+
+    @Test
+    @DisplayName("실패 1: 비즈니스 로직 에러 but Ack 수행 (로그만 남김)")
+    void testConsumeCouponRequest_ServiceError() throws Exception {
+        // given
+        UUID couponId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID sagaId = UUID.randomUUID();
+        CouponUseRequestMessage request = new CouponUseRequestMessage(couponId, userId, sagaId);
+        String jsonMessage = objectMapper.writeValueAsString(request);
+
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        // 서비스가 에러를 뱉도록 임시 설정
+        doThrow(new RuntimeException("=== DB 연결 오류")).when(couponIssueService).useCoupon(any(), any());
+
+        // when
+        kafkaConsumer.consumeCouponRequest(jsonMessage, ack);
+
+        // then
+        verify(couponIssueService, times(1)).useCoupon(couponId, userId);
+        verify(ack, times(1)).acknowledge();
+    }
+
+    @Test
+    @DisplayName("실패 2: JSON 형식이 파싱 오류 but Ack 수행")
+    void testConsumeCouponRequest_JsonParseError() {
+        // given
+        String invalidJson = "{ \"weird_field\": \"value\" "; // 깨진 JSON 형식
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        // when
+        kafkaConsumer.consumeCouponRequest(invalidJson, ack);
+
+        // then
+        // 파싱 오류 - 서비스 로직 실행 X
+        verify(couponIssueService, never()).useCoupon(any(), any());
+
+        // Ack 수행
+        verify(ack, times(1)).acknowledge();
+    }
+}


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #65

## 📝 Description
**1. 쿠폰 단건 유효성 검증 internal api 추가**
- `/api/v1/internal/coupons/{couponIssueId}/validate?userId={userId}`
- dto로 반환하는 게 계산하실 때 편할 거 같아서 검증 응답 dto를 새로 생성해 넣어뒀습니다. (쿠폰 발급 ID, 쿠폰 ID, 쿠폰명, 할인률)

**2. `coupon-use-request` 컨슈머 구현**
- infra(KafkaConfig/KafkaConsumer/CouponUseRequestMessage(dto))

**3. 쿠폰 임시 sql 파일 추가 (테스트용)**

## 🌐 Test Result

<details>
<summary> 🎫 쿠폰 유효성 검증 </summary>

<img width="976" height="668" alt="스크린샷 2025-12-08 130926" src="https://github.com/user-attachments/assets/2d8b8efb-d7cc-46ca-b737-031709806042" />
<img width="980" height="685" alt="스크린샷 2025-12-08 131032" src="https://github.com/user-attachments/assets/3beacf1c-6fb9-43ad-9734-0dc874d6847a" />
<img width="976" height="701" alt="스크린샷 2025-12-08 131105" src="https://github.com/user-attachments/assets/543beb0d-ec60-47cc-b0f6-50d3f995c448" />
<img width="985" height="708" alt="스크린샷 2025-12-08 131225" src="https://github.com/user-attachments/assets/bd0e6121-70d5-4dc4-9e63-fe1f2627d015" />

</details>

<details>
<summary> 🌐 컨슈머 구현 테스트 결과 </summary>

<img width="1788" height="174" alt="스크린샷 2025-12-08 145822" src="https://github.com/user-attachments/assets/27c2b7a4-3a22-49c0-acfa-90c49d90c9ef" />


</details>


## 🔎 To Reviewer

- 저희 서버 시간이 UTC 기준으로 설정되어있는데 (DB 데이터 저장, 조회 시 UTC로 반환) 그대로 둬도 괜찮을까요? 
- > 나중에 docker-compose 에서 timeZone설정하면 됨 ✅
- kafka Consumer 패키지, 구조, 로직 확인 한 번 해주세요. 추가 또는 수정이 필요한 곳 말씀해주십쇼 👀
- 쿠폰 쪽에서도 producer를 추가해 성공 / 실패 응답 주는 게 좋을 지..
