### PR TITLE
feat: [payment] PG TID 저장 및 결제 취소 기능 구현 (아웃박스 이벤트 발행 포함)

### DIFF
--- a/payment/src/main/java/com/high/payment/PaymentApplication.java
+++ b/payment/src/main/java/com/high/payment/PaymentApplication.java
@@ -2,8 +2,10 @@ package com.high.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PaymentApplication {
 
 	public static void main(String[] args) {

--- a/payment/src/main/java/com/high/payment/application/dto/CreatePaymentRequest.java
+++ b/payment/src/main/java/com/high/payment/application/dto/CreatePaymentRequest.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 public record CreatePaymentRequest (
 	UUID orderId,
-	UUID userId,
+	String userId,
 	BigDecimal amount,
 	String paymentMethod
 ) {}

--- a/payment/src/main/java/com/high/payment/application/dto/CreatePaymentResponse.java
+++ b/payment/src/main/java/com/high/payment/application/dto/CreatePaymentResponse.java
@@ -9,7 +9,7 @@ import com.high.payment.domain.model.Payment;
 public record CreatePaymentResponse (
 	UUID paymentId,
 	UUID orderId,
-	UUID userId,
+	String userId,
 	BigDecimal amount,
 	String status
 ) {

--- a/payment/src/main/java/com/high/payment/application/dto/IamportPaymentInfo.java
+++ b/payment/src/main/java/com/high/payment/application/dto/IamportPaymentInfo.java
@@ -1,0 +1,18 @@
+package com.high.payment.application.dto;
+
+import java.math.BigDecimal;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class IamportPaymentInfo {
+	private final String impUid;        // PG사 고유 결제 ID
+	private final String merchantUid;   // 가맹점 주문 ID (우리측 OrderId)
+	private final BigDecimal amount;    // 실제 결제된 금액 (정합성 검증 대상)
+	private final String pgTid;         // PG사 거래 번호 (DB에 저장)
+	private final String status;
+}

--- a/payment/src/main/java/com/high/payment/application/dto/IamportWebhookDto.java
+++ b/payment/src/main/java/com/high/payment/application/dto/IamportWebhookDto.java
@@ -1,7 +1,13 @@
 package com.high.payment.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record IamportWebhookDto (
+
+	@JsonProperty("imp_uid")
 	String impUid, // 아임포트 거래 고유 번호
+
+	@JsonProperty("merchant_uid")
 	String merchantUid, // 상점 거래 고유 번호 (우리의 orderId 또는 paymentId가 될 수 있음)
 	String status // 결제 상태 (ready, paid, cancelled, failed)
 ) {

--- a/payment/src/main/java/com/high/payment/application/dto/PaymentCompletedEvent.java
+++ b/payment/src/main/java/com/high/payment/application/dto/PaymentCompletedEvent.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 public record PaymentCompletedEvent (
 	UUID paymentId,
 	UUID orderId,
-	UUID userId,
+	String userId,
 	BigDecimal amount,
 	String finalStatus
 ) {}

--- a/payment/src/main/java/com/high/payment/application/port/out/IamportClientPort.java
+++ b/payment/src/main/java/com/high/payment/application/port/out/IamportClientPort.java
@@ -1,9 +1,15 @@
 package com.high.payment.application.port.out;
 
+import com.high.payment.application.dto.IamportPaymentInfo;
 import java.math.BigDecimal;
 import java.util.UUID;
 
 public interface IamportClientPort {
 	// 실제 결제 요청을 보내고 PG사 거래 ID(imp_uid)를 반환받음
 	String requestPayment(UUID orderId, BigDecimal amount, String method);
+
+	IamportPaymentInfo getPaymentInfo(String impUid);
+
+	// 금액 불일치 시 PG사에 취소 요청
+	void cancelPayment(String impUid, BigDecimal amount,String reason);
 }

--- a/payment/src/main/java/com/high/payment/application/port/out/KafkaMessagePublisherPort.java
+++ b/payment/src/main/java/com/high/payment/application/port/out/KafkaMessagePublisherPort.java
@@ -1,0 +1,8 @@
+package com.high.payment.application.port.out;
+
+import com.high.payment.domain.model.PaymentOutbox;
+
+public interface KafkaMessagePublisherPort {
+	// Outbox 이벤트를 받아 지정된 토픽에 발행합니다.
+	void publish(PaymentOutbox outbox, String topic);
+}

--- a/payment/src/main/java/com/high/payment/application/port/out/OutboxPublisherPort.java
+++ b/payment/src/main/java/com/high/payment/application/port/out/OutboxPublisherPort.java
@@ -1,0 +1,13 @@
+package com.high.payment.application.port.out;
+
+import java.util.List;
+
+import com.high.payment.domain.model.PaymentOutbox;
+
+public interface OutboxPublisherPort {
+	List<PaymentOutbox> findPendingEvents(int limit);
+
+	void publish(PaymentOutbox event);
+
+	void markAsSent(PaymentOutbox event);
+}

--- a/payment/src/main/java/com/high/payment/application/service/OutboxPollingPublisherService.java
+++ b/payment/src/main/java/com/high/payment/application/service/OutboxPollingPublisherService.java
@@ -1,0 +1,54 @@
+package com.high.payment.application.service;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.high.payment.application.port.out.KafkaMessagePublisherPort;
+import com.high.payment.domain.model.PaymentOutbox;
+import com.high.payment.domain.port.out.PaymentOutboxRepositoryPort;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxPollingPublisherService {
+
+	private final PaymentOutboxRepositoryPort outboxRepository;
+	private final KafkaMessagePublisherPort kafkaPublisher;
+
+	private static final String PAYMENT_TOPIC = "payment-events";
+
+	@Scheduled(fixedRate = 5000) // 5초마다 실행
+	@Transactional // 조회 및 삭제를 하나의 트랜잭션으로 묶어 원자성을 보장
+	public void publishOutboxEvents() {
+		// 1. 미발행된 이벤트 조회 (최대 100건)
+		List<PaymentOutbox> pendingEvents = outboxRepository.findTop100ByOrderByCreatedAtAsc();
+
+		if (pendingEvents.isEmpty()) {
+			return;
+		}
+
+		log.info("[Scheduler] {}건의 Outbox 이벤트를 발견했습니다. 발행을 시작합니다.", pendingEvents.size());
+
+		// 2. 이벤트 발행
+		for (PaymentOutbox outbox : pendingEvents) {
+			try {
+				// Outbox 데이터와 정의된 토픽으로 Kafka 발행 Port 호출
+				kafkaPublisher.publish(outbox, PAYMENT_TOPIC);
+				log.debug("Outbox ID: {} 발행 성공.", outbox.getId());
+			} catch (Exception e) {
+				log.error(" Outbox ID: {} Kafka 발행 실패. 재시도 예정.", outbox.getId(), e);
+
+			}
+		}
+
+		// 트랜잭션이 성공적으로 커밋될 경우에만 삭제가 확정됩니다.
+		outboxRepository.deleteAll(pendingEvents);
+		log.info("{}건의 Outbox 이벤트 발행 및 DB 삭제 처리 완료.", pendingEvents.size());
+	}
+}

--- a/payment/src/main/java/com/high/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/high/payment/application/service/PaymentService.java
@@ -11,4 +11,8 @@ public interface PaymentService {
 	CreatePaymentResponse createPayment(CreatePaymentRequest request);
 
 	CreatePaymentResponse getPayment(UUID paymentId);
+
+	void verifyAndFinalizePayment(String impUid, String merchantUid);
+
+	void cancelPayment(UUID orderId);
 }

--- a/payment/src/main/java/com/high/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/high/payment/application/service/PaymentServiceImpl.java
@@ -4,11 +4,13 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.payment.application.dto.CreatePaymentRequest;
 import com.high.payment.application.dto.CreatePaymentResponse;
+import com.high.payment.application.dto.IamportPaymentInfo;
 import com.high.payment.application.dto.PaymentCompletedEvent;
 import com.high.payment.application.port.out.IamportClientPort;
 import com.high.payment.domain.model.Payment;
@@ -16,7 +18,8 @@ import com.high.payment.domain.model.PaymentOutbox;
 import com.high.payment.domain.model.PaymentStatus;
 import com.high.payment.domain.port.out.PaymentOutboxRepositoryPort;
 import com.high.payment.domain.port.out.PaymentRepositoryPort;
-import com.high.payment.domain.repository.PaymentRepository;
+
+import com.high.payment.domain.repository.PaymentRepository; // 사용되지 않을 수 있지만, 임시로 유지
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,11 +29,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PaymentServiceImpl implements PaymentService {
 
-	private final PaymentRepository paymentRepository;
+	// private final PaymentRepository paymentRepository; //
 	private final PaymentOutboxRepositoryPort outboxRepository;
 	private final IamportClientPort iamportClient;
 	private final ObjectMapper objectMapper;
-	private final PaymentRepositoryPort paymentRepositoryPort; // DB Repository
+	private final PaymentRepositoryPort paymentRepositoryPort; // Hexagonal Port 사용
 
 	@Override
 	@Transactional // DB 저장과 Outbox 저장을 하나의 트랜잭션으로 묶음
@@ -65,8 +68,8 @@ public class PaymentServiceImpl implements PaymentService {
 			log.error("PG 결제 승인 실패: {}", e.getMessage());
 		}
 
-		// 5. Payment 저장
-		Payment savedPayment = paymentRepository.save(payment);
+		// 5. Payment 저장 (Port 사용으로 통일)
+		Payment savedPayment = paymentRepositoryPort.save(payment);
 
 		// 6. Outbox 저장 (이벤트 발행 보장)
 		try {
@@ -105,7 +108,7 @@ public class PaymentServiceImpl implements PaymentService {
 		Payment savedPayment = paymentRepositoryPort.save(payment);
 
 		// 3. Outbox에 이벤트 저장 (나중에 Kafka로 발행됨)
-		// paymentOutboxRepositoryPort.save(createPaymentRequestedEvent(savedPayment));
+		// paymentOutboxRepositoryPort.save(createPaymentRequestedEvent(savedPayment)); // 주석 처리 유지
 
 		// 4. 응답 DTO 반환
 		return CreatePaymentResponse.from(savedPayment);
@@ -119,5 +122,130 @@ public class PaymentServiceImpl implements PaymentService {
 												   () -> new RuntimeException("결제 정보를 찾을 수 없습니다. ID: " + paymentId));
 
 		return CreatePaymentResponse.from(payment);
+	}
+
+	@Override
+	@Transactional
+	public void verifyAndFinalizePayment(String impUid, String merchantUid) {
+
+		//  1. MerchantUid 필수 값 체크 및 UUID 변환 (오류 발생 방지 로직)
+		if (!StringUtils.hasText(merchantUid)) { // StringUtils.hasText(String)는 null 또는 공백을 체크합니다.
+			log.error("MerchantUid가 누락되었습니다. Webhook 데이터 오류.");
+			throw new IllegalArgumentException("MerchantUid가 누락되었습니다.");
+		}
+
+		UUID orderId;
+		try {
+			// MerchantUid를 UUID로 변환 시도
+			orderId = UUID.fromString(merchantUid);
+		} catch (IllegalArgumentException e) {
+			log.error("MerchantUid 형식이 유효한 UUID가 아닙니다: {}", merchantUid);
+			throw new IllegalArgumentException("유효하지 않은 MerchantUid 형식입니다.", e);
+		}
+
+		log.info(" [Service] 결제 검증 시작: ImpUid={}, OrderId={}", impUid, orderId);
+
+		// 2. DB에서 초기 결제 정보 조회 (Order ID 사용)
+		Payment payment = paymentRepositoryPort.findByOrderId(orderId)
+											   .orElseThrow(() -> new RuntimeException("DB에 결제 요청 정보가 없습니다. OrderId: " + orderId));
+
+		// 3. PG사에서 실제 결제 정보 조회 (IamportClientPort 사용)
+		IamportPaymentInfo pgInfo = iamportClient.getPaymentInfo(impUid);
+
+		String pgTid = pgInfo.getPgTid();
+		if (!StringUtils.hasText(pgTid)) {
+			log.error(" PG사로부터 유효한 PG TID를 받지 못했습니다. ImpUid={}", impUid);
+			payment.fail();
+			paymentRepositoryPort.save(payment);
+			throw new RuntimeException("PG사 정보 조회 실패: 유효한 거래번호(PG TID)가 누락되었습니다.");
+		}
+
+		// 4. 결제 검증 (금액 일치 여부 확인)
+		if (payment.getAmount().compareTo(pgInfo.getAmount()) != 0) {
+			log.error("금액 불일치 탐지! DB: {} vs PG: {}. 위변조 방지 취소 요청.",
+					  payment.getAmount(), pgInfo.getAmount());
+
+			// 4-1. PG사에 결제 취소 요청
+			iamportClient.cancelPayment(impUid, pgInfo.getAmount(), "금액 불일치로 인한 취소");
+
+			// 4-2. DB 상태 FAIL로 변경
+			payment.fail();
+			paymentRepositoryPort.save(payment);
+
+			throw new RuntimeException("결제 금액 불일치로 인한 검증 실패.");
+		}
+
+		// 5. 결제 완료 상태 확정 및 DB 저장
+		payment.complete(pgTid);
+		paymentRepositoryPort.save(payment);
+
+		// 6. Outbox 저장 및 이벤트 발행 (주문 서비스 통보)
+		try {
+			PaymentCompletedEvent outboxPayload = new PaymentCompletedEvent(
+				payment.getId(), payment.getOrderId(), payment.getUserId(),
+				payment.getAmount(), payment.getStatus().name()
+			);
+
+			String jsonPayload = objectMapper.writeValueAsString(outboxPayload);
+			PaymentOutbox outbox = PaymentOutbox.create(payment.getId(), "payment.completed", jsonPayload);
+			outboxRepository.save(outbox);
+			log.info("Outbox 저장 완료. 결제 완료 이벤트 발행 예정.");
+
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Outbox JSON 변환 에러", e);
+		}
+	}
+
+	@Override
+	@Transactional
+	public void cancelPayment(UUID orderId) {
+
+		log.info(" [Service] 결제 취소 시작: OrderId={}", orderId);
+
+		// 1. 결제 조회
+		Payment payment = paymentRepositoryPort.findByOrderId(orderId)
+											   .orElseThrow(() -> new RuntimeException("결제 정보를 찾을 수 없습니다."));
+
+		// 2. 이미 취소되었거나 완료되지 않은 건인지 확인
+		if (payment.getStatus() != PaymentStatus.COMPLETED) {
+			throw new RuntimeException("취소할 수 없는 상태입니다.");
+		}
+
+		if (!StringUtils.hasText(payment.getPgTid())) {
+			log.error("PG TID 누락, 환불에 필요한 PG TID가 없습니다. OrderId={}", orderId);
+			throw new RuntimeException("PG사에 환불 요청할 거래 번호(PG TID)가 누락되었습니다.");
+		}
+
+		// 3. PG사 환불 요청 (Mock)
+		try {
+			iamportClient.cancelPayment(payment.getPgTid(), payment.getAmount(), "고객 요청 취소");
+			log.info("[Service] PG사 취소 요청 성공");
+		} catch (Exception e) {
+			throw new RuntimeException("PG사 환불 실패: " + e.getMessage());
+		}
+
+		// 4. DB 상태 변경 (CANCELED)
+		payment.cancel();
+		paymentRepositoryPort.save(payment);
+
+		// 5. Outbox 이벤트 저장 (payment.canceled)
+		try {
+			// 이벤트 페이로드 생성
+			// Payment 객체 자체를 Payload로 사용하거나, 별도 DTO 생성
+			String payload = objectMapper.writeValueAsString(payment);
+
+			// Outbox 생성 (인자 3개: aggregateId, eventType, payload)
+			PaymentOutbox outbox = PaymentOutbox.create(
+				payment.getId(),
+				"payment.canceled",
+				payload
+			);
+
+			outboxRepository.save(outbox);
+			log.info("[Outbox] 취소 이벤트 저장 완료.");
+
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("JSON 변환 실패", e);
+		}
 	}
 }

--- a/payment/src/main/java/com/high/payment/domain/model/Payment.java
+++ b/payment/src/main/java/com/high/payment/domain/model/Payment.java
@@ -29,11 +29,11 @@ public class Payment {
 	@GeneratedValue(strategy = GenerationType.UUID)
 	private UUID id;
 
-	@Column(name = "order_id", nullable = false)
+	@Column(name = "order_id", nullable = false, unique = true)
 	private UUID orderId; // 주문 서비스에서 넘어온 ID
 
-	@Column(name = "user_id", nullable = false)
-	private UUID userId;
+	@Column(name = "user_id", nullable = false, length = 50)
+	private String userId;
 
 	@Column(name = "payment_amount", nullable = false)
 	private BigDecimal amount;
@@ -52,13 +52,19 @@ public class Payment {
 	@Builder.Default
 	private LocalDateTime createdAt = LocalDateTime.now();
 
-	// 상태 변경 로직 (도메인 책임)
+	public void fail() {
+		this.status = PaymentStatus.FAILED;
+	}
+
 	public void complete(String pgTid) {
 		this.status = PaymentStatus.COMPLETED;
 		this.pgTid = pgTid;
 	}
 
-	public void fail() {
-		this.status = PaymentStatus.FAILED;
+	public void cancel() {
+		if (this.status != PaymentStatus.COMPLETED) {
+			throw new IllegalStateException("COMPLETED 상태가 아니면 취소할 수 없습니다.");
+		}
+		this.status = PaymentStatus.CANCELED;
 	}
 }

--- a/payment/src/main/java/com/high/payment/domain/model/PaymentOutbox.java
+++ b/payment/src/main/java/com/high/payment/domain/model/PaymentOutbox.java
@@ -5,11 +5,15 @@ import java.util.UUID;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,31 +21,52 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "payment_outbox")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class PaymentOutbox {
+
+	public enum OutboxStatus {
+		PENDING, SENT
+	}
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
 	private UUID id;
 
 	private UUID aggregateId; // Payment ID
 	private String aggregateType; // "PAYMENT"
+	@Column(name = "event_type", nullable = false)
 	private String eventType;     // "payment.completed" or "payment.failed"
 
 	@Column(columnDefinition = "TEXT") // JSON Payload가 길 수 있음
 	private String payload;
 
-	private String status; // PENDING, PUBLISHED
+	private String topic;
+	private String messageKey;
+
+	@Enumerated(EnumType.STRING)
+	private OutboxStatus status; // PENDING, PUBLISHED
 
 	private LocalDateTime createdAt;
 
 	public static PaymentOutbox create(UUID aggregateId, String eventType, String payload) {
-		PaymentOutbox outbox = new PaymentOutbox();
-		outbox.aggregateId = aggregateId;
-		outbox.aggregateType = "PAYMENT";
-		outbox.eventType = eventType;
-		outbox.payload = payload;
-		outbox.status = "PENDING";
-		outbox.createdAt = LocalDateTime.now();
-		return outbox;
+		return PaymentOutbox.builder()
+							.aggregateId(aggregateId)
+							.aggregateType("PAYMENT")
+							.eventType(eventType)
+							.payload(payload)
+							.topic("payment-events") // 기본 토픽 설정 (필요시 파라미터로 받기)
+							.messageKey(aggregateId.toString()) // 기본 키 설정
+							.status(OutboxStatus.PENDING) // Enum 사용
+							.createdAt(LocalDateTime.now())
+							.build();
 	}
 
+	public void markAsSent() {
+		this.status = OutboxStatus.SENT;
+	}
+
+	public String getTopic(){
+		return this.eventType;
+	}
 }

--- a/payment/src/main/java/com/high/payment/domain/model/PaymentStatus.java
+++ b/payment/src/main/java/com/high/payment/domain/model/PaymentStatus.java
@@ -4,5 +4,6 @@ public enum PaymentStatus {
 	REQUESTED,   // 결제 의도만 생성된 상태
 	COMPLETED,   // PG에서 결제 승인 완료
 	FAILED,      // 결제 실패
+	CANCELED,
 	REFUNDED     // 환불 완료 (나중에 사용)
 }

--- a/payment/src/main/java/com/high/payment/domain/port/out/PaymentOutboxRepositoryPort.java
+++ b/payment/src/main/java/com/high/payment/domain/port/out/PaymentOutboxRepositoryPort.java
@@ -1,7 +1,23 @@
 package com.high.payment.domain.port.out;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+import com.high.payment.domain.model.PaymentOutbox.OutboxStatus;
 import com.high.payment.domain.model.PaymentOutbox;
 
 public interface PaymentOutboxRepositoryPort {
 	PaymentOutbox save(PaymentOutbox outbox);
+
+	Optional<PaymentOutbox> findById(UUID id);
+
+	// 발행되지 않은 이벤트 목록을 조회합니다.
+	List<PaymentOutbox> findTop100ByOrderByCreatedAtAsc();
+
+	List<PaymentOutbox> findAllByStatus(OutboxStatus status, Pageable pageable);
+
+	//  발행된 이벤트들을 삭제합니다.
+	void deleteAll(List<PaymentOutbox> outboxes);
 }

--- a/payment/src/main/java/com/high/payment/domain/port/out/PaymentRepositoryPort.java
+++ b/payment/src/main/java/com/high/payment/domain/port/out/PaymentRepositoryPort.java
@@ -9,4 +9,6 @@ public interface PaymentRepositoryPort {
 	Payment save(Payment payment);
 
 	Optional<Payment> findById(UUID id);
+	
+	Optional<Payment> findByOrderId(UUID orderId);
 }

--- a/payment/src/main/java/com/high/payment/exception/PaymentErrorCode.java
+++ b/payment/src/main/java/com/high/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,29 @@
+package com.high.payment.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.library.module.exception.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements BaseErrorCode {
+	// Application Exception
+	PAYMENT_BAD_REQUEST(5000, HttpStatus.BAD_REQUEST, "잘못된 결제 요청입니다."),
+
+	// Domain Exception
+	PAYMENT_NOT_FOUND(5001, HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
+	INVALID_PAYMENT_STATUS(5002, HttpStatus.BAD_REQUEST, "현재 상태에서는 결제 상태를 변경할 수 없습니다."),
+	PAYMENT_VERIFICATION_FAILED(5003, HttpStatus.BAD_REQUEST, "결제 정보 검증(금액 불일치)에 실패했습니다."),
+	PAYMENT_CANCELLATION_NOT_ALLOWED(5004, HttpStatus.BAD_REQUEST, "결제 취소가 허용되지 않는 상태입니다."),
+
+	// PG 연동 Exception
+	PG_CLIENT_ERROR(5005, HttpStatus.SERVICE_UNAVAILABLE, "PG사 연동 중 오류가 발생했습니다.")
+	;
+
+	private final int code;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/payment/src/main/java/com/high/payment/exception/PaymentException.java
+++ b/payment/src/main/java/com/high/payment/exception/PaymentException.java
@@ -1,0 +1,21 @@
+package com.high.payment.exception;
+
+import com.library.module.exception.BaseErrorCode;
+
+public class PaymentException extends RuntimeException {
+	private final BaseErrorCode errorCode;
+
+	public PaymentException(BaseErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public PaymentException(BaseErrorCode errorCode, String detailMessage) {
+		super(detailMessage);
+		this.errorCode = errorCode;
+	}
+
+	public BaseErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/client/IamportClientAdapter.java
+++ b/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/client/IamportClientAdapter.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
+import com.high.payment.application.dto.IamportPaymentInfo;
 import com.high.payment.application.port.out.IamportClientPort;
 
 import lombok.extern.slf4j.Slf4j;
@@ -24,5 +25,37 @@ public class IamportClientAdapter implements IamportClientPort {
 
 		// 실패 테스트 시 아래 주석 해제
 		// throw new RuntimeException("잔액 부족");
+	}
+
+	@Override
+	public IamportPaymentInfo getPaymentInfo(String impUid) {
+		log.info(" [PG Mock] PG사 API 호출 시뮬레이션: impUid={}", impUid);
+
+		if (impUid.contains("success")) {
+			// 성공 응답 (25000.00원, status: paid)
+			return IamportPaymentInfo.builder()
+									 .impUid(impUid)
+									 .merchantUid("b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e")
+									 .amount(BigDecimal.valueOf(25000))
+									 .status("paid")
+									 .pgTid("TID-MOCK-" + impUid.toUpperCase())
+									 .build();
+		} else {
+			// 실패 응답 (status: failed)
+			return IamportPaymentInfo.builder()
+									 .impUid(impUid)
+									 .merchantUid("b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e")
+									 .amount(BigDecimal.valueOf(0))
+									 .status("failed")
+									 .pgTid(null)
+									 .build();
+		}
+	}
+
+	@Override
+	public void cancelPayment(String impUid, BigDecimal amount, String reason) {
+		log.warn(" [PG Mock] PG사에 결제 취소 요청 시뮬레이션 실행: ImpUid={}, Amount={}, Reason={}",
+				 impUid, amount, reason);
+		// 실제로는 여기에서 외부 API 호출 및 응답 처리가 이루어집니다.
 	}
 }

--- a/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/client/KafkaProducerAdapter.java
+++ b/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/client/KafkaProducerAdapter.java
@@ -1,0 +1,15 @@
+package com.high.payment.infrastrcutre.adapter.out.client;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class KafkaProducerAdapter implements KafkaProducerPort {
+	@Override
+	public void send(String topic, String key, String payload) {
+		log.info("[KAFKA MOCK] 이벤트 발행: Topic={}, Key={}, Payload={}",
+				 topic, key, payload.substring(0, Math.min(payload.length(), 100)) + "...");
+	}
+}

--- a/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/client/KafkaProducerPort.java
+++ b/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/client/KafkaProducerPort.java
@@ -1,0 +1,5 @@
+package com.high.payment.infrastrcutre.adapter.out.client;
+
+public interface KafkaProducerPort {
+	void send(String topic, String key, String payload);
+}

--- a/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/kafka/KafkaPublisherAdapter.java
+++ b/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/kafka/KafkaPublisherAdapter.java
@@ -1,0 +1,30 @@
+package com.high.payment.infrastrcutre.adapter.out.kafka;
+
+import org.springframework.stereotype.Component;
+
+import com.high.payment.application.port.out.KafkaMessagePublisherPort;
+import com.high.payment.domain.model.PaymentOutbox;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaPublisherAdapter implements KafkaMessagePublisherPort {
+
+	@Override
+	public void publish(PaymentOutbox outbox, String topic) {
+		log.info("[Kafka Mock] 이벤트 발행 시뮬레이션 시작.");
+
+		// 1. 발행 정보 로깅
+		log.info("-> Topic: {}, EventType: {}, Outbox ID: {}",
+				 topic, outbox.getEventType(), outbox.getId());
+
+		// 2. 실제 페이로드 로깅 (디버그 레벨)
+		log.debug("-> Payload: {}", outbox.getPayload());
+
+		// 3. (Mock 성공 가정)
+		log.info("[Kafka Mock] 이벤트 발행 시뮬레이션 성공적으로 완료.");
+	}
+}

--- a/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/OutboxPublisherAdapter.java
+++ b/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/OutboxPublisherAdapter.java
@@ -1,0 +1,39 @@
+package com.high.payment.infrastrcutre.adapter.out.persistence;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import com.high.payment.application.port.out.OutboxPublisherPort;
+import com.high.payment.domain.model.PaymentOutbox;
+import com.high.payment.domain.port.out.PaymentOutboxRepositoryPort;
+import com.high.payment.infrastrcutre.adapter.out.client.KafkaProducerPort;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxPublisherAdapter implements OutboxPublisherPort {
+
+	private final PaymentOutboxRepositoryPort outboxRepository;
+	private final KafkaProducerPort kafkaProducerPort;
+
+	@Override
+	public List<PaymentOutbox> findPendingEvents(int limit) {
+		return outboxRepository.findAllByStatus(PaymentOutbox.OutboxStatus.PENDING, PageRequest.of(0, limit));
+	}
+
+	@Override
+	public void publish(PaymentOutbox event) {
+		kafkaProducerPort.send(event.getTopic(), event.getMessageKey(), event.getPayload());
+		log.info("[KAFKA] Outbox Event ID {} 발행 완료.", event.getId());
+	}
+
+	@Override
+	public void markAsSent(PaymentOutbox event) {
+
+	}
+}

--- a/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/PaymentJpaRepository.java
+++ b/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/PaymentJpaRepository.java
@@ -1,5 +1,6 @@
 package com.high.payment.infrastrcutre.adapter.out.persistence;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.high.payment.domain.model.Payment;
 
 public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
+
+	Optional<Payment> findByOrderId(UUID orderID);
 }

--- a/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/PaymentOutboxJpaRepository.java
+++ b/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/PaymentOutboxJpaRepository.java
@@ -1,10 +1,16 @@
 package com.high.payment.infrastrcutre.adapter.out.persistence;
 
+import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.high.payment.domain.model.PaymentOutbox;
 
 public interface PaymentOutboxJpaRepository extends JpaRepository<PaymentOutbox, UUID> {
+
+	List<PaymentOutbox> findTop100ByOrderByCreatedAtAsc();
+
+	List<PaymentOutbox> findAllByStatus(PaymentOutbox.OutboxStatus status, Pageable pageable);
 }

--- a/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/PaymentOutboxRepositoryAdapter.java
+++ b/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/PaymentOutboxRepositoryAdapter.java
@@ -1,5 +1,10 @@
 package com.high.payment.infrastrcutre.adapter.out.persistence;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import com.high.payment.domain.model.PaymentOutbox;
@@ -16,5 +21,25 @@ public class PaymentOutboxRepositoryAdapter implements PaymentOutboxRepositoryPo
 	@Override
 	public PaymentOutbox save(PaymentOutbox outbox) {
 		return jpaRepository.save(outbox);
+	}
+
+	@Override
+	public Optional<PaymentOutbox> findById(UUID id) {
+		return jpaRepository.findById(id);
+	}
+
+	@Override
+	public List<PaymentOutbox> findTop100ByOrderByCreatedAtAsc() {
+		return jpaRepository.findTop100ByOrderByCreatedAtAsc();
+	}
+
+	@Override
+	public List<PaymentOutbox> findAllByStatus(PaymentOutbox.OutboxStatus status, Pageable pageable) {
+		return jpaRepository.findAllByStatus(status, pageable);
+	}
+
+	@Override
+	public void deleteAll(List<PaymentOutbox> outboxes) {
+		jpaRepository.deleteAll(outboxes);
 	}
 }

--- a/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/PaymentRepositoryAdapter.java
+++ b/payment/src/main/java/com/high/payment/infrastrcutre/adapter/out/persistence/PaymentRepositoryAdapter.java
@@ -25,4 +25,9 @@ public class PaymentRepositoryAdapter implements PaymentRepositoryPort {
 	public Optional<Payment> findById(UUID id) {
 		return jpaRepository.findById(id);
 	}
+
+	@Override
+	public Optional<Payment> findByOrderId(UUID orderId) {
+		return jpaRepository.findByOrderId(orderId);
+	}
 }

--- a/payment/src/main/java/com/high/payment/presentation/PaymentController.java
+++ b/payment/src/main/java/com/high/payment/presentation/PaymentController.java
@@ -27,8 +27,7 @@ public class PaymentController {
 	private final PaymentService paymentService;
 
 	/**
-	 * [Webhook Endpoint] 아임포트(Iamport)로부터 결제 상태 변경 알림을 수신합니다.
-	 * 이 Webhook을 통해 결제의 최종 상태를 확정하고 정합성을 검증합니다.
+	 * [Webhook Endpoint] 아임포트(Iamport)로부터 결제 상태 변경 알림을 수신
 	 * * @param webhookDto 아임포트가 전송한 Webhook 데이터
 	 */
 	@PostMapping("/iamport/webhook")
@@ -36,19 +35,20 @@ public class PaymentController {
 
 		log.info("Iamport Webhook 수신: MerchantUid={}, Status={}", webhookDto.merchantUid(), webhookDto.status());
 
-		// 1. Webhook 상태에 따라 처리 (paid, cancelled 등)
 		if ("paid".equals(webhookDto.status())) {
 
-			// 2. 서비스 로직 위임 (결제 정보 조회 및 최종 확정 로직)
-			// (TODO: PaymentService에 handleWebhook 이나 verifyPayment 메서드 구현 필요)
-			// paymentService.verifyAndFinalizePayment(webhookDto.impUid(), webhookDto.merchantUid());
+			try {
+				paymentService.verifyAndFinalizePayment(webhookDto.impUid(), webhookDto.merchantUid());
+				log.info("Webhook 처리 성공. Payment 확정 완료.");
+			} catch (Exception e) {
+				log.error(" Webhook 처리 중 오류 발생 (정합성 검증 실패 등): {}", e.getMessage(), e);
+				return ResponseEntity.status(HttpStatus.OK).build();
+			}
 
 		} else if ("failed".equals(webhookDto.status()) || "cancelled".equals(webhookDto.status())) {
-			// 결제 실패/취소 처리 로직
-
+			log.warn("결제 실패 또는 취소 Webhook 수신. MerchantUid={}", webhookDto.merchantUid());
 		}
 
-		// Iamport에게 200 OK 응답을 보내야 재시도를 하지 않습니다.
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 
@@ -80,5 +80,13 @@ public class PaymentController {
 
 		// 3. 200 OK 응답 반환
 		return ResponseEntity.ok(response);
+	}
+
+	// 결제 취소 요청
+	@PostMapping("/{orderId}/cancel")
+	public ResponseEntity<Void> cancelPayment(@PathVariable UUID orderId) {
+		// 취소 로직 호출
+		paymentService.cancelPayment(orderId);
+		return ResponseEntity.noContent().build(); // 204 No Content
 	}
 }


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #63 

## 📝 Description
- 결제 서비스의 핵심 기능인 $\text{PG}$ $\text{TID}$ 저장 및 결제 취소 $\text{API}$ 기능을 $\text{Hexagonal Architecture}$ 기반으로 완성.
## 🌐 Test Result
<img width="1780" height="786" alt="image" src="https://github.com/user-attachments/assets/be67903a-6825-4ead-835b-5769a9061ac7" />
<img width="800" height="551" alt="image" src="https://github.com/user-attachments/assets/841d148e-a065-4e6d-adc8-12b7a12cf4a2" />

결제 생성 후 -> webhook 수신 -> 결제 완료(COMPLETED -> CANCLED) 

## 🔎 To Reviewer
- 에러코드 부분 미반영
- TODO : 주문 ID로 조회 기능 구현 및 오전 회초리 맞은 부분 점검 ...................
- 하드 코딩된 부분 수정 예정입니다
