### PR TITLE
feat: User Service - Internal User API

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -32,7 +32,7 @@ ext {
 dependencies {
 
 	// Common Libraries
-	implementation 'com.github.sharedeffort:common-module:v1.1.9'
+	implementation 'com.github.sharedeffort:common-module:v1.2.0'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.13'
 

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -41,6 +41,11 @@ spring:
               predicates:
                 - Path=/api/v1/master/**
 
+            - id: user-internal-service
+              uri: lb://user-service
+              predicates:
+                - Path=/api/v1/internal/users/**
+
             - id: user-service
               uri: lb://user-service
               predicates:

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -79,10 +79,15 @@ spring:
                 - Path=/carts/v3/api-docs
 
             # 4. Coupon Service (8600)
+            - id: coupon-internal-service
+              uri: lb://coupon-service
+              predicates:
+                - Path=/api/v1/internal/coupons/**
+
             - id: coupon-service
               uri: lb://coupon-service
               predicates:
-                - Path=/api/v1/coupons/**, /api/v1/internal/coupons/**
+                - Path=/api/v1/coupons/**
 
             - id: coupon-docs
               uri: lb://coupon-service

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -31,7 +31,7 @@ ext {
 
 dependencies {
 	// Common Libraries
-	implementation 'com.github.sharedeffort:common-module:v1.1.9'
+	implementation 'com.github.sharedeffort:common-module:v1.2.0'
 	implementation 'com.github.sharedeffort:common-jpa:v1.0.3'
 	implementation 'com.github.sharedeffort:common-security:v1.1.0'
 

--- a/user/src/main/java/com/high/user/application/dto/request/BatchUserRequest.java
+++ b/user/src/main/java/com/high/user/application/dto/request/BatchUserRequest.java
@@ -1,0 +1,20 @@
+package com.high.user.application.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 다건 사용자 조회 Request DTO
+ * <p>
+ * Internal API에서 여러 사용자의 정보를 한 번에 조회할 때 사용
+ * </p>
+ *
+ * @param userIds 조회할 사용자 ID 목록
+ */
+public record BatchUserRequest(
+        @NotEmpty(message = "사용자 ID 목록은 필수입니다")
+        List<UUID> userIds
+) {
+}

--- a/user/src/main/java/com/high/user/application/dto/response/InternalUserResponse.java
+++ b/user/src/main/java/com/high/user/application/dto/response/InternalUserResponse.java
@@ -1,0 +1,50 @@
+package com.high.user.application.dto.response;
+
+import com.high.user.domain.entity.User;
+
+import java.util.UUID;
+
+/**
+ * 내부 서비스 간 통신용 사용자 정보 Response DTO
+ * <p>
+ * Order/Payment/Coupon Service가 User 정보를 조회할 때 사용
+ * </p>
+ *
+ * @param userId 사용자 고유 ID
+ * @param email 이메일
+ * @param name 사용자 이름
+ * @param role 권한 (USER, SELLER, MASTER)
+ * @param isActive 활성화 여부
+ * @param phoneNumber 전화번호
+ * @param deliveryAddress 배송 주소
+ * @param detailAddress 상세 주소
+ */
+public record InternalUserResponse(
+        UUID userId,
+        String email,
+        String name,
+        String role,
+        Boolean isActive,
+        String phoneNumber,
+        String deliveryAddress,
+        String detailAddress
+) {
+    /**
+     * User Entity에서 InternalUserResponse로 변환
+     *
+     * @param user User Entity
+     * @return InternalUserResponse DTO
+     */
+    public static InternalUserResponse from(User user) {
+        return new InternalUserResponse(
+                user.getUserId(),
+                user.getEmail(),
+                user.getName(),
+                user.getRole().name(),
+                user.getIsActive(),
+                user.getPhoneNumber(),
+                user.getDeliveryAddress(),
+                user.getDetailAddress()
+        );
+    }
+}

--- a/user/src/main/java/com/high/user/application/service/InternalUserService.java
+++ b/user/src/main/java/com/high/user/application/service/InternalUserService.java
@@ -1,0 +1,65 @@
+package com.high.user.application.service;
+
+import com.high.user.application.dto.response.InternalUserResponse;
+import com.high.user.domain.entity.User;
+import com.high.user.domain.exception.UserNotFoundException;
+import com.high.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 내부 서비스 간 통신용 사용자 조회 Service
+ * <p>
+ * Order/Payment/Coupon Service에서 User 정보를 조회할 때 사용
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InternalUserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 단건 조회 - Order/Payment/Coupon Service에서 사용
+     *
+     * @param userId 사용자 고유 ID
+     * @return InternalUserResponse
+     * @throws UserNotFoundException 사용자를 찾을 수 없을 때
+     */
+    public InternalUserResponse getUserById(UUID userId) {
+        log.info("[Internal API] Fetching user with id: {}", userId);
+
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> {
+                    log.warn("[Internal API] User not found with id: {}", userId);
+                    return new UserNotFoundException();
+                });
+
+        return InternalUserResponse.from(user);
+    }
+
+    /**
+     * 다건 조회 - Batch 조회 (Order Service 등에서 사용)
+     *
+     * @param userIds 사용자 ID 목록
+     * @return InternalUserResponse 리스트
+     */
+    public List<InternalUserResponse> getUsersByIds(List<UUID> userIds) {
+        log.info("[Internal API] Fetching users with ids: {} (count: {})", userIds, userIds.size());
+
+        List<User> users = userRepository.findByUserIdInAndDeletedAtIsNull(userIds);
+
+        log.info("[Internal API] Found {} users out of {} requested", users.size(), userIds.size());
+
+        return users.stream()
+                .map(InternalUserResponse::from)
+                .toList();
+    }
+}

--- a/user/src/main/java/com/high/user/domain/repository/UserRepository.java
+++ b/user/src/main/java/com/high/user/domain/repository/UserRepository.java
@@ -4,6 +4,7 @@ import com.high.user.domain.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -29,4 +30,7 @@ public interface UserRepository {
 
     // Search by email (partial match)
     Page<User> findByEmailContainingAndDeletedAtIsNull(String email, Pageable pageable);
+
+    // Find by IDs (Batch query for Internal API)
+    List<User> findByUserIdInAndDeletedAtIsNull(List<UUID> userIds);
 }

--- a/user/src/main/java/com/high/user/infrastructure/persistence/JpaUserRepository.java
+++ b/user/src/main/java/com/high/user/infrastructure/persistence/JpaUserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -26,4 +27,7 @@ public interface JpaUserRepository extends JpaRepository<User, UUID> {
 
     // Search by email (partial match)
     Page<User> findByEmailContainingAndDeletedAtIsNull(String email, Pageable pageable);
+
+    // Find by IDs (Batch query for Internal API)
+    List<User> findByUserIdInAndDeletedAtIsNull(List<UUID> userIds);
 }

--- a/user/src/main/java/com/high/user/infrastructure/persistence/UserRepositoryAdaptor.java
+++ b/user/src/main/java/com/high/user/infrastructure/persistence/UserRepositoryAdaptor.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -49,5 +50,10 @@ public class UserRepositoryAdaptor implements UserRepository {
     @Override
     public Page<User> findByEmailContainingAndDeletedAtIsNull(String email, Pageable pageable) {
         return jpaUserRepository.findByEmailContainingAndDeletedAtIsNull(email, pageable);
+    }
+
+    @Override
+    public List<User> findByUserIdInAndDeletedAtIsNull(List<UUID> userIds) {
+        return jpaUserRepository.findByUserIdInAndDeletedAtIsNull(userIds);
     }
 }

--- a/user/src/main/java/com/high/user/presentation/InternalController.java
+++ b/user/src/main/java/com/high/user/presentation/InternalController.java
@@ -1,0 +1,72 @@
+package com.high.user.presentation;
+
+import com.high.user.application.dto.request.BatchUserRequest;
+import com.high.user.application.dto.response.InternalUserResponse;
+import com.high.user.application.service.InternalUserService;
+import com.library.module.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 내부 서비스 간 통신용 User API Controller
+ * <p>
+ * Order/Payment/Coupon Service에서 User 정보를 조회할 때 사용
+ * Gateway에서 JWT 검증 후 X-User-Id, X-User-Role 헤더 추가
+ * </p>
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/internal/users")
+@PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
+public class InternalController {
+
+    private final InternalUserService internalUserService;
+
+    /**
+     * 단건 사용자 조회
+     * <p>
+     * GET /api/v1/internal/users/{userId}
+     * </p>
+     *
+     * @param userId 사용자 고유 ID
+     * @return 200 OK + ApiResponse<InternalUserResponse>
+     */
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<InternalUserResponse>> getUserById(
+            @PathVariable UUID userId) {
+
+        log.info("[Internal API] GET /api/v1/internal/users/{}", userId);
+        InternalUserResponse response = internalUserService.getUserById(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 다건 사용자 조회 (Batch)
+     * <p>
+     * POST /api/v1/internal/users/batch
+     * </p>
+     *
+     * @param request 사용자 ID 목록 (BatchUserRequest)
+     * @return 200 OK + ApiResponse<List<InternalUserResponse>>
+     */
+    @PostMapping("/batch")
+    public ResponseEntity<ApiResponse<List<InternalUserResponse>>> getUsersByIds(
+            @Valid @RequestBody BatchUserRequest request) {
+
+        log.info("[Internal API] POST /api/v1/internal/users/batch - size: {}",
+                request.userIds().size());
+        List<InternalUserResponse> responses =
+                internalUserService.getUsersByIds(request.userIds());
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+}

--- a/user/src/main/java/com/high/user/presentation/InternalController.java
+++ b/user/src/main/java/com/high/user/presentation/InternalController.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/internal/users")
-@PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
+@PreAuthorize("hasAnyRole('MASTER')")
 public class InternalController {
 
     private final InternalUserService internalUserService;


### PR DESCRIPTION
## Issue Number
- Closes #108

## 📝 Description

Order/Payment/Coupon Service가 User 정보를 조회할 수 있는 Internal API를 구현했습니다.

### 주요 변경사항

#### 1. X-Header 기반 인증
- **Gateway**: JWT 검증 후 X-User-Id, X-User-Role 헤더 자동 추가
- **User Service**: HeaderAuthenticationFilter가 SecurityContext에 저장
- **Spring Security**: `@PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")`
- User Service의 CouponClient와 동일한 패턴

#### 2. Internal API
- **단건 조회**: `GET /api/v1/internal/users/{userId}`
- **다건 조회**: `POST /api/v1/internal/users/batch`
- Soft Delete 필터링 자동 적용

#### 3. DTO 구현
- **InternalUserResponse**: userId, email, name, role, isActive, phoneNumber, deliveryAddress, detailAddress
- **BatchUserRequest**: userIds (List<UUID>)

#### 4. Repository 확장
- `findByUserIdInAndDeletedAtIsNull(List<UUID> userIds)` 메서드 추가
- IN 쿼리로 다건 조회 성능 최적화

## 🌐 Test Result

### 단건 조회
<img width="781" height="776" alt="image" src="https://github.com/user-attachments/assets/65e1c87f-7ede-4f89-a923-20b900cc6c61" />

### 다건 조회
<img width="1141" height="867" alt="image" src="https://github.com/user-attachments/assets/55d51252-acc7-47f8-a7dc-c760c9a4ac4f" />

## 🔎 To Reviewer

- 정상 작동 하는지 확인 부탁드립니다.
- 게이트웨이로 보내서 처리하거나 각 서비스에서 X-Header에 UUID, Role을 담아 보내셔도 됩니다.