### PR TITLE
fix: Gateway & User Swagger 접근 설정 개선

### DIFF
--- a/coupon/src/main/java/com/high/coupon/infrastructure/security/SecurityConfig.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/security/SecurityConfig.java
@@ -20,7 +20,11 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/internal/**").permitAll()
+                        .requestMatchers(
+                                "/api/v1/internal/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -194,7 +194,44 @@ services:
       # JWT Secret
       JWT_SECRET: ${JWT_SECRET}
 
-  # 9. Coupon Service (쿠폰 관리)
+  # 9. Product Service (상품 관리)
+  product-service:
+    image: gradle:8.5-jdk17
+    container_name: msa-product
+    working_dir: /app
+    volumes:
+      - ./product:/app
+      - gradle-cache:/root/.gradle
+    command: gradle bootRun --no-daemon
+    ports:
+      - "8200:8200"
+    depends_on:
+      mysql:
+        condition: service_started
+      redis:
+        condition: service_started
+      config-server:
+        condition: service_healthy
+      eureka-server:
+        condition: service_healthy
+    networks:
+      - msa-network
+    environment:
+      # Docker 프로파일 활성화
+      SPRING_PROFILES_ACTIVE: docker
+      # Config Server 직접 연결
+      SPRING_CLOUD_CONFIG_URI: http://config-server:8888
+      SPRING_CLOUD_CONFIG_DISCOVERY_ENABLED: "false"
+      # MySQL Docker 컨테이너 호스트 오버라이드
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/product_service?serverTimezone=UTC&characterEncoding=UTF-8
+      # Redis Docker 환경 오버라이드
+      SPRING_DATA_REDIS_HOST: redis
+      REDIS_HOST: redis
+      # Eureka Docker 환경 오버라이드
+      EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
+      EUREKA_INSTANCE_HOSTNAME: product-service
+
+  # 10. Coupon Service (쿠폰 관리)
   coupon-service:
     image: gradle:8.5-jdk17
     container_name: msa-coupon

--- a/external/src/main/java/com/high/external/infrastructure/security/SecurityConfig.java
+++ b/external/src/main/java/com/high/external/infrastructure/security/SecurityConfig.java
@@ -27,6 +27,10 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 미사용
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(handling -> handling

--- a/gateway/src/main/java/com/high/gateway/filter/JwtAuthenticationGlobalFilter.java
+++ b/gateway/src/main/java/com/high/gateway/filter/JwtAuthenticationGlobalFilter.java
@@ -33,14 +33,21 @@ public class JwtAuthenticationGlobalFilter implements GlobalFilter, Ordered {
 
     // 인증 제외 경로
     private static final List<String> EXCLUDED_PATHS = List.of(
+            // User Service - Public API
             "/api/v1/users/signup",
             "/api/v1/users/login",
             "/api/v1/users/reissue",
-            "/docs",
+
+            // Swagger UI & OpenAPI Docs
             "/docs/**",
-            "/actuator/**",
-            "/**/v3/api-docs",
-            "/**/v3/api-docs/**"
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/*/v3/api-docs/**",  // /{service}/v3/api-docs/**
+            "/webjars/**",
+
+            // Monitoring
+            "/actuator/**"
     );
 
     @Override

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -55,6 +55,8 @@ spring:
               uri: lb://user-service
               predicates:
                 - Path=/users/v3/api-docs
+              filters:
+                - StripPrefix=1
 
             # 2. Product Service (8200)
             - id: product-service
@@ -66,6 +68,8 @@ spring:
               uri: lb://product-service
               predicates:
                 - Path=/products/v3/api-docs
+              filters:
+                - StripPrefix=1
 
             # 3. Cart Service (8700)
             - id: cart-service
@@ -77,6 +81,8 @@ spring:
               uri: lb://cart-service
               predicates:
                 - Path=/carts/v3/api-docs
+              filters:
+                - StripPrefix=1
 
             # 4. Coupon Service (8600)
             - id: coupon-internal-service
@@ -93,6 +99,8 @@ spring:
               uri: lb://coupon-service
               predicates:
                 - Path=/coupons/v3/api-docs
+              filters:
+                - StripPrefix=1
 
             # 5. Order Service (8400)
             - id: order-service
@@ -104,6 +112,8 @@ spring:
               uri: lb://order-service
               predicates:
                 - Path=/orders/v3/api-docs
+              filters:
+                - StripPrefix=1
 
             # 6. Payment Service (8300)
             - id: payment-service
@@ -115,6 +125,8 @@ spring:
               uri: lb://payment-service
               predicates:
                 - Path=/payments/v3/api-docs
+              filters:
+                - StripPrefix=1
 
             # 7. Orchestration Service (8900)
             - id: orchestration-service
@@ -126,6 +138,8 @@ spring:
               uri: lb://orchestration-service
               predicates:
                 - Path=/orchestrations/v3/api-docs
+              filters:
+                - StripPrefix=1
 
             # 8. External Service (8500)
             - id: external-service
@@ -137,6 +151,8 @@ spring:
               uri: lb://external-service
               predicates:
                 - Path=/externals/v3/api-docs
+              filters:
+                - StripPrefix=1
 
 springdoc:
   swagger-ui:

--- a/orchestration/src/main/java/com/high/orchestration/infrastructure/config/SecurityConfig.java
+++ b/orchestration/src/main/java/com/high/orchestration/infrastructure/config/SecurityConfig.java
@@ -21,6 +21,10 @@ public class SecurityConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 미사용
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/v3/api-docs/**",
+                    "/swagger-ui/**",
+                    "/swagger-ui.html").permitAll()
                 .anyRequest().authenticated()
             );
 

--- a/order/src/main/java/com/high/order/infrastructure/config/SecurityConfig.java
+++ b/order/src/main/java/com/high/order/infrastructure/config/SecurityConfig.java
@@ -21,6 +21,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 미사용
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers(
+                            "/v3/api-docs/**",
+                            "/swagger-ui/**",
+                            "/swagger-ui.html").permitAll()
                     .anyRequest().authenticated()
                 );
 

--- a/product/src/main/java/com/high/product/infrastructure/config/SecurityConfig.java
+++ b/product/src/main/java/com/high/product/infrastructure/config/SecurityConfig.java
@@ -23,7 +23,11 @@ public class SecurityConfig {
 				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				// 공개 엔드포인트 (필요 시 추가)
-				.requestMatchers("/api/v1/health").permitAll()
+				.requestMatchers(
+						"/api/v1/health",
+						"/v3/api-docs/**",
+						"/swagger-ui/**",
+						"/swagger-ui.html").permitAll()
 				.anyRequest().authenticated()
 			);
 

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+	// Springdoc OpenAPI
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/user/src/main/java/com/high/user/infrastructure/config/SecurityConfig.java
+++ b/user/src/main/java/com/high/user/infrastructure/config/SecurityConfig.java
@@ -50,7 +50,10 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/v1/users/signup",
                                 "/api/v1/users/login",
-                                "/api/v1/users/reissue"
+                                "/api/v1/users/reissue",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
                         ).permitAll()
                         // 나머지는 인증 필요
                         .anyRequest().authenticated())


### PR DESCRIPTION
## Issue Number
- closed #118 

## 📝 Description
- gateway/.../application.yaml: 경로 라우팅 오류(핵심원인)

```
            - id: user-docs
              uri: lb://user-service
              predicates:
                - Path=/users/v3/api-docs
              filters:
                - StripPrefix=1
```
- gateway/.../JwtAuthenticationGlobalFilter.java : 경로 페턴 개선 및 정리
```
    // 인증 제외 경로
    private static final List<String> EXCLUDED_PATHS = List.of(
            // User Service - Public API
            "/api/v1/users/signup",
            "/api/v1/users/login",
            "/api/v1/users/reissue",

            // Swagger UI & OpenAPI Docs
            "/docs/**",
            "/swagger-ui/**",
            "/swagger-ui.html",
            "/v3/api-docs/**",
            "/*/v3/api-docs/**",  // /{service}/v3/api-docs/**
            "/webjars/**",

            // Monitoring
            "/actuator/**"
    );
```
- user/.../SecurityConfig.java: Swagger 접근 허용(**각 서비스 수정함**)
```
                        .requestMatchers(
                                "/api/v1/users/signup",
                                "/api/v1/users/login",
                                "/api/v1/users/reissue",
                                "/v3/api-docs/**",
                                "/swagger-ui/**",
                                "/swagger-ui.html"
                        ).permitAll()
```

## 🌐 Test Result
<img width="1126" height="949" alt="image" src="https://github.com/user-attachments/assets/50837e56-82b8-40c7-8d80-ab849f84d9a7" />


## 🔎 To Reviewer
- SecurityConfig.java가 있는 서비스에는 모두 Swagger경로 permitAll()했습니다.
- 관련해서 이야기 하실 부분은 내일 아침에 하면 될 것 같습니다.
