### PR TITLE
feat: 주문절차 성공메세지 처리 컨슈머 구현

### DIFF
--- a/config/src/main/resources/config-repo/external-service.yml
+++ b/config/src/main/resources/config-repo/external-service.yml
@@ -33,6 +33,14 @@ management:
     sampling:
       probability: 1.0
 
+kafka:
+  bootstrap-servers: localhost:9092
+  consumer:
+    group-id: external-service-group
+
+  topic:
+    order-process-success: order-process-success
+
 logging:
   level:
     com.high.external: INFO

--- a/external/build.gradle
+++ b/external/build.gradle
@@ -31,6 +31,9 @@ ext {
 
 dependencies {
 
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 
     // slack

--- a/external/src/main/java/com/high/external/infrastructure/kafka/config/KafkaConsumerConfig.java
+++ b/external/src/main/java/com/high/external/infrastructure/kafka/config/KafkaConsumerConfig.java
@@ -1,0 +1,77 @@
+package com.high.external.infrastructure.kafka.config;
+
+
+import com.fasterxml.jackson.databind.deser.std.StringDeserializer;
+import com.high.external.infrastructure.kafka.dto.OrderProcessSuccessEventDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, OrderProcessSuccessEventDto> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        // ErrorHandlingDeserializer가 사용할 실제 Deserializer를 설정
+        config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+
+        // JSON Deserializer 설정
+        config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        config.put(JsonDeserializer.VALUE_DEFAULT_TYPE, OrderProcessSuccessEventDto.class.getName());
+        config.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+
+        return new DefaultKafkaConsumerFactory<>(
+                config,
+                new org.apache.kafka.common.serialization.StringDeserializer(),
+                new ErrorHandlingDeserializer<>(new JsonDeserializer<>(OrderProcessSuccessEventDto.class, false))
+        );
+    }
+
+    @Bean
+    public DefaultErrorHandler errorHandler() {
+        return new DefaultErrorHandler(new FixedBackOff(1000L, 3L));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, OrderProcessSuccessEventDto> kafkaListenerContainerFactory(
+            ConsumerFactory<String, OrderProcessSuccessEventDto> consumerFactory,
+            DefaultErrorHandler errorHandler
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, OrderProcessSuccessEventDto> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(errorHandler);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+
+        return factory;
+    }
+}

--- a/external/src/main/java/com/high/external/infrastructure/kafka/consumer/OrderProcessSuccessEventConsumer.java
+++ b/external/src/main/java/com/high/external/infrastructure/kafka/consumer/OrderProcessSuccessEventConsumer.java
@@ -1,0 +1,75 @@
+package com.high.external.infrastructure.kafka.consumer;
+
+import com.high.external.application.service.SlackMessageServiceV1;
+import com.high.external.infrastructure.kafka.dto.OrderProcessSuccessEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderProcessSuccessEventConsumer {
+
+    private final SlackMessageServiceV1 messageServiceV1;
+
+    @KafkaListener(
+            topics = "${kafka.topic.order-process-success}",
+            groupId = "${kafka.consumer.group-id}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consumerOrderProcessSuccessEvent(
+            @Payload OrderProcessSuccessEventDto event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset
+    ) {
+        log.info("=== Kafka Message Received ===");
+        log.info("Topic: {}, Partition: {}, Offset: {}", topic, partition, offset);
+        log.info("Event: userId={}, orderId={}", event.getUserId(), event.getOrderId());
+
+        try {
+            // 주문 상품명 포맷팅 (예: 샤프 외 1건)
+            String itemSummary = "";
+            List<String> items = event.getOrderItemNameList();
+
+            if (items != null && !items.isEmpty()) {
+                String firstItem = items.get(0);
+                int otherCount = items.size() - 1;
+                itemSummary = (otherCount > 0)
+                        ? String.format("%s 외 %d건", firstItem, otherCount)
+                        : firstItem;
+            }
+
+            // 메시지 본문 생성
+            String message = String.format(
+                    "주문이 완료되었습니다.\n\n" +
+                            "주문 날짜: %s\n" +
+                            "주문 번호: %s\n" +
+                            "주문 상품: %s\n" +
+                            "주문 총액: %,d원\n\n" +
+                            "배송이 시작되면 다시 안내드리겠습니다.\n" +
+                            "감사합니다.",
+                    event.getCreatedAt(),
+                    event.getOrderId(),
+                    itemSummary,
+                    event.getPaidAmount()
+            );
+
+            // 슬랙 전송 (채널 ID 사용)
+            messageServiceV1.slackMessageSend("C0A3XR53W2K", message);
+
+            log.info("✅ Slack message sent for order: {}", event.getOrderId());
+
+        } catch (Exception e) {
+            log.error("❌ Failed to process order event: {}", event.getOrderId(), e);
+            throw e;
+        }
+    }
+}

--- a/external/src/main/java/com/high/external/infrastructure/kafka/dto/OrderProcessSuccessEventDto.java
+++ b/external/src/main/java/com/high/external/infrastructure/kafka/dto/OrderProcessSuccessEventDto.java
@@ -1,0 +1,34 @@
+package com.high.external.infrastructure.kafka.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderProcessSuccessEventDto {
+
+    @JsonProperty("orderId")
+    private UUID orderId;
+
+    @JsonProperty("userId")
+    private UUID userId;
+
+    @JsonProperty("paidAmount")
+    private Integer paidAmount;
+
+    @JsonProperty("createdAt")
+    private String createdAt;
+
+    @JsonProperty("orderItemNameList")
+    private List<String> orderItemNameList;
+
+}


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #142 

## 📝 Description
- 주문절차 성공메세지 처리 컨슈머 구현


## 🌐 Test Result
<details>
<summary> 테스트 메세지 발행 (order-process-success)</summary>
<div markdown="1">
<img width="1316" height="448" alt="스크린샷 2025-12-18 오후 8 42 46" src="https://github.com/user-attachments/assets/e8aa571e-322e-4dcf-9b66-395756b70112" />
</div>
</details>

<details>
<summary> 메세지 처리후 슬랙 알림 전송 </summary>
<div markdown="1">
<img width="432" height="210" alt="스크린샷 2025-12-18 오후 8 40 45" src="https://github.com/user-attachments/assets/ca8e6fa6-fbc9-4aed-82b5-37cdb67e1da3" />
</div>
</details>

## 🔎 To Reviewer
- 알림 전송 테스트 이유로 알림메세지 채널을 따로 만들어서 확인했습니다.
  테스트가 필요하신분은 해당채널에 참여하셔서 테스트 하시면 됩니다.(참여가 안돼시면 말씀해주세요)
- 수정이 필요한 부분이있으면 알려주세요
