### PR TITLE
feat:[payment] 결제 Intent 분리 및 Webhook 기반 결제 확정 및  Payment 구조 장비

### DIFF
--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -65,8 +65,6 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
-
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 dependencyManagement {

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -62,8 +62,9 @@ dependencies {
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
-	// orchestration
-    // implementation 'com.high:orchestration:0.0.1-SNAPSHOT'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }

--- a/payment/src/main/java/com/high/payment/application/dto/PaymentCreateCommandRequest.java
+++ b/payment/src/main/java/com/high/payment/application/dto/PaymentCreateCommandRequest.java
@@ -5,7 +5,8 @@ import java.util.UUID;
 public record PaymentCreateCommandRequest(
 	UUID sagaId,
 	UUID orderId,
-	UUID userId
+	UUID userId,
+	Integer paymentPrice
 ) {
 
 }

--- a/payment/src/main/java/com/high/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/high/payment/application/service/PaymentServiceImpl.java
@@ -24,7 +24,9 @@ import com.high.payment.domain.model.PaymentOutbox;
 import com.high.payment.domain.model.PaymentStatus;
 import com.high.payment.domain.port.out.PaymentOutboxRepositoryPort;
 import com.high.payment.domain.port.out.PaymentRepositoryPort;
-import com.high.payment.domain.port.out.UserValidationPort;
+import com.high.payment.domain.port.out.PaymentSagaRepositoryPort;
+import com.high.payment.domain.model.PaymentSaga;
+import com.high.payment.domain.model.PaymentSagaStatus;
 import com.high.payment.exception.PaymentException;
 import com.high.payment.exception.PaymentErrorCode;
 
@@ -36,15 +38,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PaymentServiceImpl implements PaymentService {
 
-	// private final PaymentRepository paymentRepository; //
 	private final PaymentOutboxRepositoryPort outboxRepository;
 	private final IamportClientPort iamportClient;
 	private final ObjectMapper objectMapper;
 	private final PaymentRepositoryPort paymentRepositoryPort; // Hexagonal Port 사용
 	private final UserServiceClient userServiceClient;
-	private final PaymentSagaEventPort eventPublisher;
-	private final UserValidationPort userValidationPort;
 	private final PaymentSagaEventPort paymentSagaEventPort;
+	private final PaymentSagaRepositoryPort paymentSagaRepositoryPort;
 
 	@Override
 	@Transactional // DB 저장과 Outbox 저장을 하나의 트랜잭션으로 묶음
@@ -297,57 +297,77 @@ public class PaymentServiceImpl implements PaymentService {
 		UUID sagaId = command.sagaId();
 		UUID orderId = command.orderId();
 		UUID userId = command.userId();
+		Integer paymentPrice = command.paymentPrice();
 
-		log.info("[Saga] 결제 요청 수신: SagaId={}, OrderId={}, UserId={}", sagaId, orderId, userId);
+		log.info("[Saga] 결제 Intent 생성 요청 수신: SagaId={}, OrderId={}, UserId={}, Price={}",
+				 sagaId, orderId, userId, paymentPrice);
+
+		// 0) paymentPrice 검증 (Intent 생성 단계에서도 최소 검증은 필요)
+		if (paymentPrice == null || paymentPrice <= 0) {
+			PaymentSagaResultMessage fail = new PaymentSagaResultMessage(
+				sagaId, orderId, userId, false,
+				"paymentPrice는 1 이상이어야 합니다.",
+				PaymentErrorCode.PAYMENT_BAD_REQUEST.getCode()
+			);
+			paymentSagaEventPort.publishPaymentResult(fail);
+			return;
+		}
+
+		// 1) 멱등 처리: sagaId로 먼저 조회해서 이미 SUCCESS/FAIL이면 즉시 종료
+		var existingSagaOpt = paymentSagaRepositoryPort.findBySagaId(sagaId);
+		if (existingSagaOpt.isPresent()) {
+			var existingSaga = existingSagaOpt.get();
+
+			if (existingSaga.getStatus() != PaymentSagaStatus.PENDING) {
+				log.warn("[Saga] 이미 처리된 SagaId={} status={} - skip", sagaId, existingSaga.getStatus());
+				return;
+			}
+		}
+
+		// 2) saga row 없으면 생성(PENDING)
+		var saga = existingSagaOpt.orElseGet(() ->
+												 paymentSagaRepositoryPort.save(PaymentSaga.start(sagaId, orderId, userId)
+												 ));
 
 		try {
-			// 1. 유저 검증 (UserServiceClient는 UUID를 받도록 수정됨)
-			try {
-				userServiceClient.validateUser(userId);
-				log.info("[Saga] 유저 검증 성공: UserId={}", userId);
-			} catch (Exception e) {
-				throw new RuntimeException("유저 유효성 검증 실패: " + e.getMessage());
-			}
+			// 3) 유저 검증 (필요하면 유지)
+			userServiceClient.validateUser(userId);
 
-			// 2. [중요] DTO 필드 누락으로 인한 임시 데이터 생성
-			log.warn("[Saga] 주의: DTO에 결제금액 정보가 없어 '0원'으로 임시 처리합니다.");
+			// 4) 결제 레코드(PENDING) 생성만 한다. (PG 승인 X, complete() X)
+			Payment payment = Payment.builder()
+									 .orderId(orderId)
+									 .userId(userId)
+									 .paymentPrice(paymentPrice)
+									 .paymentMethod("CARD")
+									 .status(PaymentStatus.PENDING)
+									 .build();
 
-			CreatePaymentRequest tempRequest = new CreatePaymentRequest(
-				orderId,
-				userId,     // Payment 도메인은 String userId를 사용함
-				0,       // 임시 값: 0원
-				"SAGA_TEST_CARD"       // 임시 값: 테스트용 결제수단
-			);
+			Payment saved = paymentRepositoryPort.save(payment);
 
-			// 3. 기존 결제 로직 재사용
-			processPayment(tempRequest);
+			// 5) 오케스트레이터에게 “결제 생성 성공” 알림 -> true: 결제 완료가 아닌 결제 생성
+			saga.success("Payment saga success");
+			paymentSagaRepositoryPort.save(saga);
 
-			// 4. 성공 이벤트 발행 (Orchestrator에게 알림)
+			// 6) 오케스트레이터 결과 발행
 			PaymentSagaResultMessage successResult = new PaymentSagaResultMessage(
-				sagaId,
-				orderId,
-				userId,
-				true,
-				"Payment successful",
-				null
+				sagaId, orderId, userId, true, "Payment successful", null
 			);
 			paymentSagaEventPort.publishPaymentResult(successResult);
-			log.info("[Saga] 결제 성공 이벤트 발행 완료");
 
-		} catch (PaymentException pe) {
-			log.error("[Saga] 결제 처리 중 실패 발생: {}", pe.getMessage());
+			log.info("[Saga] 결제 Intent 생성 완료: paymentId={}", saved.getId());
 
-			// 5. 실패 이벤트 발행 (보상 트랜잭션 유도)
-			PaymentSagaResultMessage failResult = new PaymentSagaResultMessage(
+		} catch (Exception e) {
+			log.error("[Saga] 결제 Intent 생성 실패: {}", e.getMessage(), e);
+
+			PaymentSagaResultMessage fail = new PaymentSagaResultMessage(
 				sagaId,
 				orderId,
 				userId,
 				false,
-				"알 수 없는 오류: " + pe.getMessage(),
-				PaymentErrorCode.PAYMENT_INTERNAL_SERVER_ERROR.getCode()
+				"Payment intent create failed: " + e.getMessage(),
+				5003
 			);
-			// 💡 단일 메서드 호출로 변경
-			paymentSagaEventPort.publishPaymentResult(failResult);
+			paymentSagaEventPort.publishPaymentResult(fail);
 		}
 	}
 }

--- a/payment/src/main/java/com/high/payment/domain/model/PaymentSaga.java
+++ b/payment/src/main/java/com/high/payment/domain/model/PaymentSaga.java
@@ -1,0 +1,86 @@
+package com.high.payment.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "payment_saga")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentSaga {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	@Column(nullable = false, unique = true)
+	private UUID sagaId;
+
+	@Column(nullable = false)
+	private UUID orderId;
+
+	@Column(nullable = false)
+	private UUID userId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private PaymentSagaStatus status;
+
+	@Column
+	private Integer errorCode;
+
+	@Column(length = 500)
+	private String message;
+
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
+
+	public static PaymentSaga start(UUID sagaId, UUID orderId, UUID userId) {
+		LocalDateTime now = LocalDateTime.now();
+		return PaymentSaga.builder()
+						  .sagaId(sagaId)
+						  .orderId(orderId)
+						  .userId(userId)
+						  .status(PaymentSagaStatus.PENDING)
+						  .createdAt(now)
+						  .updatedAt(now)
+						  .build();
+	}
+
+	public void success(String message) {
+		this.status = PaymentSagaStatus.SUCCESS;
+		this.message = message;
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	public void fail(Integer errorCode, String message) {
+		this.status = PaymentSagaStatus.FAIL;
+		this.errorCode = errorCode;
+		this.message = message;
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	public void timeout(String message) {
+		this.status = PaymentSagaStatus.TIMEOUT;
+		this.message = message;
+		this.updatedAt = LocalDateTime.now();
+	}
+}

--- a/payment/src/main/java/com/high/payment/domain/model/PaymentSagaStatus.java
+++ b/payment/src/main/java/com/high/payment/domain/model/PaymentSagaStatus.java
@@ -1,0 +1,8 @@
+package com.high.payment.domain.model;
+
+public enum PaymentSagaStatus {
+	PENDING,
+	SUCCESS,
+	FAIL,
+	TIMEOUT
+}

--- a/payment/src/main/java/com/high/payment/domain/model/PaymentStatus.java
+++ b/payment/src/main/java/com/high/payment/domain/model/PaymentStatus.java
@@ -5,5 +5,6 @@ public enum PaymentStatus {
 	COMPLETED,   // PG에서 결제 승인 완료
 	FAILED,      // 결제 실패
 	CANCELED,
-	REFUNDED     // 환불 완료 (나중에 사용)
+	REFUNDED,     // 환불 완료 (나중에 사용)
+	EXPIRED // 시간 초과
 }

--- a/payment/src/main/java/com/high/payment/domain/port/out/PaymentSagaRepositoryPort.java
+++ b/payment/src/main/java/com/high/payment/domain/port/out/PaymentSagaRepositoryPort.java
@@ -1,0 +1,11 @@
+package com.high.payment.domain.port.out;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.high.payment.domain.model.PaymentSaga;
+
+public interface PaymentSagaRepositoryPort {
+	PaymentSaga save(PaymentSaga saga);
+	Optional<PaymentSaga> findBySagaId(UUID sagaId);
+}

--- a/payment/src/main/java/com/high/payment/infrastructure/adapter/out/persistence/JpaPaymentSagaRepository.java
+++ b/payment/src/main/java/com/high/payment/infrastructure/adapter/out/persistence/JpaPaymentSagaRepository.java
@@ -1,0 +1,12 @@
+package com.high.payment.infrastructure.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.high.payment.domain.model.PaymentSaga;
+
+public interface JpaPaymentSagaRepository extends JpaRepository<PaymentSaga, UUID> {
+	Optional<PaymentSaga> findBySagaId(UUID sagaId);
+}

--- a/payment/src/main/java/com/high/payment/infrastructure/adapter/out/persistence/PaymentSagaRepositoryAdapter.java
+++ b/payment/src/main/java/com/high/payment/infrastructure/adapter/out/persistence/PaymentSagaRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.high.payment.infrastructure.adapter.out.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.high.payment.domain.model.PaymentSaga;
+import com.high.payment.domain.port.out.PaymentSagaRepositoryPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentSagaRepositoryAdapter implements PaymentSagaRepositoryPort {
+
+	private final JpaPaymentSagaRepository jpaRepo;
+
+	@Override
+	public PaymentSaga save(PaymentSaga saga) {
+		return jpaRepo.save(saga);
+	}
+
+	@Override
+	public Optional<PaymentSaga> findBySagaId(UUID sagaId) {
+		return jpaRepo.findBySagaId(sagaId);
+	}
+}

--- a/payment/src/main/java/com/high/payment/infrastructure/kafka/PaymentCommandConsumer.java
+++ b/payment/src/main/java/com/high/payment/infrastructure/kafka/PaymentCommandConsumer.java
@@ -27,7 +27,7 @@ public class PaymentCommandConsumer {
 
 
 		} catch (Exception e) {
-			log.error(e.getMessage());
+			log.error("[Consumer] payment-create-request 메시지 처리 실패. raw={}", message, e);
 		}
 	}
 }


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #136 

## 📝 Description
- 결제 생성과 실제 결제 확정 로직 분리 : 실제 결제 확정 Iamport Webhook -> verifyAndFinalizePayment에서 처리
- 결제 상태 흐름 명확화 : PENDING -> COMPLETED / FAILED / CANCELED
- SAGA 처리
- 테이블 명세 기준 DTO/Entity 정합성 맞춤

## 🌐 Test Result
- local에서 postman으로 요청한 결과를 첨부합니다.

## 🔎 ToDo
- 결제 만료 처리 : TTL 초과 시 자동 CANCELED, Redis TTL 또는 Scheduler 기반
- 결제 취소 -> 주문 취소 연계 : Kafka 이벤트 발행
