### PR TITLE
add: kafka feign 통신에 필요한 파일 및 코드 추가

### DIFF
--- a/coupon/src/main/java/com/high/coupon/infrastructure/client/OrderClient.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/client/OrderClient.java
@@ -1,6 +1,7 @@
 package com.high.coupon.infrastructure.client;
 
 import com.high.coupon.infrastructure.client.dto.OrderResponse;
+import com.high.coupon.infrastructure.config.FeignConfig;
 import com.library.module.response.ApiResponse;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
  * order <-> coupon 통신 (saga-orchestration)
  * orderId 내 couponIssueId 가져와 완료 처리를 위함
  */
-@FeignClient(name = "order-service")
+@FeignClient(name = "order-service", configuration = FeignConfig.class)
 public interface OrderClient {
 
     @GetMapping("/api/v1/orders/{orderId}")

--- a/coupon/src/main/java/com/high/coupon/infrastructure/config/FeignConfig.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/config/FeignConfig.java
@@ -1,0 +1,29 @@
+package com.high.coupon.infrastructure.config;
+
+import com.high.coupon.infrastructure.context.MessageContext;
+import com.library.security.util.SecurityContextUtil;
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class FeignConfig implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate template) {
+
+        if (MessageContext.hasContext()) {
+            template.header("X-User-Id", MessageContext.getUserId().toString());
+            template.header("X-User-Role", MessageContext.getRole());
+            return;
+        }
+
+        try {
+            template.header("X-User-Id", SecurityContextUtil.getCurrentUserIdAsString());
+            template.header("X-User-Role", SecurityContextUtil.getCurrentUserRole());
+        } catch (Exception ignored) {}
+    }
+
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/context/MessageContext.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/context/MessageContext.java
@@ -1,0 +1,32 @@
+package com.high.coupon.infrastructure.context;
+
+import java.util.UUID;
+
+public class MessageContext  {
+
+    private static final ThreadLocal<Context> context = new ThreadLocal<>();
+
+    public record Context(UUID userId, String role) {}
+
+    public static void set(UUID userId, String role) {
+        context.set(new Context(userId, role));
+    }
+
+    public static boolean hasContext() {
+        return context.get() != null;
+    }
+
+    public static UUID getUserId() {
+        Context ctx = context.get();
+        return ctx != null ? ctx.userId() : null;
+    }
+
+    public static String getRole() {
+        Context ctx = context.get();
+        return ctx != null ? ctx.role() : null;
+    }
+
+    public static void clear() {
+        context.remove();
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/kafka/consumer/CouponUseRequestConsumer.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/kafka/consumer/CouponUseRequestConsumer.java
@@ -3,6 +3,7 @@ package com.high.coupon.infrastructure.kafka.consumer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.coupon.application.CouponIssueService;
+import com.high.coupon.infrastructure.context.MessageContext;
 import com.high.coupon.infrastructure.kafka.dto.CouponUseRequestMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,6 +53,9 @@ public class CouponUseRequestConsumer {
         try {
             // JSON → DTO 역직렬화 (UUID 타입)
             dto = objectMapper.readValue(message, CouponUseRequestMessage.class);
+
+            MessageContext.set(dto.userId(), "USER");
+
             log.info("[SAGA COUPON CONSUMER: use req] 파싱 완료 sagaId: {}", dto.sagaId());
 
             // orderId 기반 wrapper 호출 (service)
@@ -71,6 +75,8 @@ public class CouponUseRequestConsumer {
             log.error("[SAGA COUPON CONSUMER: use req] 처리 실패 내용: {}, 에러: {}", message, e.getMessage());
             throw new RuntimeException("Kafka Consumer Error", e);
 
+        } finally {
+            MessageContext.clear();
         }
     }
 


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #147 

## 📝 Description
- 오케스트레이션 통신을 하는 `쿠폰 사용` 쪽에만 코드를 추가하였습니다.

## 🌐 Test Result

`유저 - 상품 - 쿠폰 - 오케스트레이션 주문 생성 흐름 테스트`

1. **주문 생성 에러 발생 없이 처리 완료**
<img width="1437" height="164" alt="스크린샷 2025-12-19 172503" src="https://github.com/user-attachments/assets/fa5373ad-00e8-401b-bb8c-d1f02c5e5036" />


---

2. **주문 생성 유저의 쿠폰 상태 업데이트 확인 (false(미사용) -> true(사용))**

(쿠폰 서비스 모듈)

<img width="1373" height="517" alt="스크린샷 2025-12-19 173754" src="https://github.com/user-attachments/assets/8da6bdc2-29b4-48ad-a2af-fcbf65f7483d" />

(쿠폰 DB)

<img width="1352" height="254" alt="스크린샷 2025-12-19 172515" src="https://github.com/user-attachments/assets/6d77ced1-4ee5-4311-9038-b5236b5561ef" />


## 🔎 To Reviewer
- 결제 제외하고 각 서비스 전부 생성, 조회, 업데이트 테스트 했을 땐 이상 없었는데 문제 있으면 말씀해주세요
