### PR TITLE
refactor: 쿠폰 정보 캐싱 및 Redis 기반 발급 유저 관리 개선

### DIFF
--- a/config/src/main/resources/config-repo/coupon-service.yml
+++ b/config/src/main/resources/config-repo/coupon-service.yml
@@ -1,6 +1,11 @@
 server:
   port: 8600
 
+# 쿠폰 발급 목록 정책
+coupon:
+  policy:
+    retention-days: 3  # 이벤트 종료 후 3일간 데이터 보관
+
 spring:
   application:
     name: coupon-service

--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // jackson 확장
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
@@ -55,6 +57,8 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // caffeine
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     // db
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
@@ -16,11 +16,13 @@ import com.high.coupon.domain.entity.CouponIssue;
 import com.high.coupon.domain.exception.CouponAlreadyIssuedException;
 import com.high.coupon.domain.exception.CouponNotOwnedException;
 import com.high.coupon.domain.repository.CouponIssueRepository;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +41,10 @@ public class CouponIssueService {
 
     private final CouponIssueEventPort couponIssueEventPort;
 
+    // config
+    @Value("${coupon.policy.retention-days}")
+    private long retentionDays;
+
     /**
      * 쿠폰 발급
      * Redis 검증 -> Kafka 메시지 발송 -> 발급 응답
@@ -50,10 +56,13 @@ public class CouponIssueService {
 
         Coupon coupon = couponReader.getCouponById(couponId);
 
+        long ttlSeconds = calculateTTL(coupon.getIssueEndAt());
+
         Long result = couponCachePort.tryIssueCoupon(
                 couponId,
                 userId,
-                coupon.getTotalQuantity()
+                coupon.getTotalQuantity(),
+                ttlSeconds
         );
 
         // 0 성공, -1 실패: 수량 소진, -2 실패: 이미 발급 받음
@@ -78,6 +87,19 @@ public class CouponIssueService {
         couponIssueRepository.save(couponIssue);
 
         log.info("[COUPON ISSUE Consumer] DB 저장 완료: userId={}, couponId={}", userId, couponId);
+    }
+
+
+    /**
+     * 발급 유저 목록 데이터 Redis 데이터 만료시간 계산 메서드
+     */
+    private long calculateTTL(LocalDateTime issueEndAt) {
+
+        // 일자 계산 = config(정책) + db(쿠폰 별 발급 종료일)
+        LocalDateTime endAtWithBuffer = issueEndAt.plusDays(retentionDays);
+
+        long seconds = Duration.between(LocalDateTime.now(), endAtWithBuffer).getSeconds();
+        return Math.max(seconds, 0); // TTL이 지난 과거 날짜 음수 방지
     }
 
 

--- a/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponIssueService.java
@@ -30,8 +30,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CouponIssueService {
 
-    private final CouponService couponService;
+    // private final CouponService couponService;
     private final CouponIssueRepository couponIssueRepository;
+    private final CouponReader couponReader;
 
     private final OrderPort orderPort;
     private final CouponCachePort couponCachePort;
@@ -47,7 +48,7 @@ public class CouponIssueService {
 
         log.info("User {} is issued a coupon", userId);
 
-        Coupon coupon = couponService.getCouponById(couponId);
+        Coupon coupon = couponReader.getCouponById(couponId);
 
         Long result = couponCachePort.tryIssueCoupon(
                 couponId,
@@ -72,7 +73,7 @@ public class CouponIssueService {
     // Consumer 호출 메서드
     @Transactional
     public void saveCouponIssue(UUID couponId, UUID userId) {
-        Coupon coupon = couponService.getCouponById(couponId);
+        Coupon coupon = couponReader.getCouponById(couponId);
         CouponIssue couponIssue = CouponIssue.issueCoupon(coupon, userId, LocalDateTime.now());
         couponIssueRepository.save(couponIssue);
 

--- a/coupon/src/main/java/com/high/coupon/application/CouponReader.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponReader.java
@@ -1,0 +1,32 @@
+package com.high.coupon.application;
+
+import com.high.coupon.application.exception.CouponNotFoundException;
+import com.high.coupon.domain.entity.Coupon;
+import com.high.coupon.domain.repository.CouponRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponReader {
+
+    private final CouponRepository couponRepository;
+
+    /**
+     * 쿠폰 ID 조회 메서드
+     */
+    @Cacheable(cacheNames = "coupon", key = "#couponId", cacheManager = "localCacheManager", sync = true)
+    public Coupon getCouponById(UUID couponId){
+
+        log.info("[CouponReader Cache] 쿠폰 조회 id={}", couponId);
+
+        return couponRepository.findById(couponId)
+                .orElseThrow(CouponNotFoundException::new);
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/application/CouponService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponService.java
@@ -4,7 +4,6 @@ import com.high.coupon.application.dto.request.CouponCreateRequest;
 import com.high.coupon.application.dto.response.CouponCreateResponse;
 import com.high.coupon.application.dto.response.CouponDetailResponse;
 import com.high.coupon.application.dto.response.CouponListResponse;
-import com.high.coupon.application.exception.CouponNotFoundException;
 import com.high.coupon.domain.entity.Coupon;
 import com.high.coupon.domain.repository.CouponRepository;
 import com.library.jpa.response.PageResponse;
@@ -26,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponService {
 
     private final CouponRepository couponRepository;
+    private final CouponReader couponReader;
 
     // 쿠폰 등록
     @Transactional
@@ -48,8 +48,9 @@ public class CouponService {
     }
 
     // 쿠폰 단건 조회
+    // todo 단건 조회 캐싱 방법 고민 (global, local)
     public CouponDetailResponse getCouponDetail(UUID couponId) {
-        Coupon coupon = getCouponById(couponId);
+        Coupon coupon = couponReader.getCouponById(couponId);
         return CouponDetailResponse.from(coupon);
     }
 
@@ -59,14 +60,6 @@ public class CouponService {
         Page<Coupon> pageResult = couponRepository.findAll(pageable);
         Page<CouponListResponse> couponList = pageResult.map(CouponListResponse::from);
         return PageResponse.fromPage(couponList, sortBy, isAsc);
-    }
-
-    /**
-     * 쿠폰 ID 조회 메서드
-     */
-    public Coupon getCouponById(UUID couponId){
-        return couponRepository.findById(couponId)
-                .orElseThrow(CouponNotFoundException::new);
     }
 
     /**

--- a/coupon/src/main/java/com/high/coupon/application/CouponService.java
+++ b/coupon/src/main/java/com/high/coupon/application/CouponService.java
@@ -4,6 +4,7 @@ import com.high.coupon.application.dto.request.CouponCreateRequest;
 import com.high.coupon.application.dto.response.CouponCreateResponse;
 import com.high.coupon.application.dto.response.CouponDetailResponse;
 import com.high.coupon.application.dto.response.CouponListResponse;
+import com.high.coupon.application.exception.CouponNotFoundException;
 import com.high.coupon.domain.entity.Coupon;
 import com.high.coupon.domain.repository.CouponRepository;
 import com.library.jpa.response.PageResponse;
@@ -25,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponService {
 
     private final CouponRepository couponRepository;
-    private final CouponReader couponReader;
 
     // 쿠폰 등록
     @Transactional
@@ -47,12 +47,14 @@ public class CouponService {
         return CouponCreateResponse.from(savedCoupon);
     }
 
+
     // 쿠폰 단건 조회
-    // todo 단건 조회 캐싱 방법 고민 (global, local)
-    public CouponDetailResponse getCouponDetail(UUID couponId) {
-        Coupon coupon = couponReader.getCouponById(couponId);
-        return CouponDetailResponse.from(coupon);
+    public CouponDetailResponse getCouponDetail(UUID couponId){
+        return couponRepository.findById(couponId)
+                .map(CouponDetailResponse::from)
+                .orElseThrow(CouponNotFoundException::new);
     }
+
 
     // 쿠폰 리스트 조회
     public PageResponse<CouponListResponse> getCouponPage(int page, int size, String sortBy, boolean isAsc) {

--- a/coupon/src/main/java/com/high/coupon/application/port/out/CouponCachePort.java
+++ b/coupon/src/main/java/com/high/coupon/application/port/out/CouponCachePort.java
@@ -6,5 +6,5 @@ import java.util.UUID;
  * Redis 관련 쿠폰 통로 역할
  */
 public interface CouponCachePort {
-    Long tryIssueCoupon(UUID couponId, UUID userId, Integer totalQuantity);
+    Long tryIssueCoupon(UUID couponId, UUID userId, Integer totalQuantity, Long ttlSeconds);
 }

--- a/coupon/src/main/java/com/high/coupon/infrastructure/config/CaffeineCacheConfig.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/config/CaffeineCacheConfig.java
@@ -1,0 +1,26 @@
+package com.high.coupon.infrastructure.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 쿠폰 정보 캐싱은 Local
+ * 특정 기능에 따라 캐싱 옵션이 달라질 수 있음 -> 이 때는 enum으로 분리하는 방법 존재
+ */
+@Configuration
+public class CaffeineCacheConfig {
+
+    @Bean
+    public CacheManager localCacheManager(){
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(60)) // 60초가 지나면 만료 todo LocalCache에서 TTL을 길게 잡으면 위험할까?
+                        .maximumSize(100) // 100개
+                );
+        return cacheManager;
+    }
+}

--- a/coupon/src/main/java/com/high/coupon/infrastructure/config/RedisConfig.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/config/RedisConfig.java
@@ -1,15 +1,104 @@
 package com.high.coupon.infrastructure.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.scripting.support.ResourceScriptSource;
 
 @Configuration
+@EnableCaching
 public class RedisConfig {
 
+    /**
+     * Redis 전용 ObjectMapper
+     * - LocalDateTime 지원
+     * - @class 미포함
+     */
+    @Bean
+    public ObjectMapper redisObjectMapper() {
+        return JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+    }
+
+    /**
+     * Redis value Serializer
+     * ObjectMapper 주입
+     */
+    @Bean
+    public Jackson2JsonRedisSerializer<Object> redisSerializer(
+            ObjectMapper redisObjectMapper
+    ) {
+        return new Jackson2JsonRedisSerializer<>(
+                redisObjectMapper,
+                Object.class
+        );
+    }
+
+    /**
+     * RedisTemplate
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory connectionFactory,
+            Jackson2JsonRedisSerializer<Object> redisValueSerializer){
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // Key -> String
+        template.setKeySerializer(new StringRedisSerializer());
+        // Value -> Json (Redis 데이터 Json으로 저장)
+        template.setValueSerializer(redisValueSerializer);
+
+        // Hash Key / Value
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(redisValueSerializer);
+
+        return template;
+    }
+
+//
+//    /**
+//     * CacheManager
+//     * Key - String, Value - Json
+//     * 기본 TTL 3일 (todo 테스트 중은 더 짧게)
+//     * todo 필요 시 커스텀 추가
+//     */
+//    @Bean
+//    public RedisCacheManager redisCacheManager(
+//            RedisConnectionFactory connectionFactory,
+//            Jackson2JsonRedisSerializer<Object> redisValueSerializer){
+//
+//        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+//                .entryTtl(Duration.ofDays(3)) // 쿠폰 정보 3일 뒤 만료
+//                .serializeKeysWith(RedisSerializationContext.SerializationPair
+//                        .fromSerializer(new StringRedisSerializer())
+//                )
+//                .serializeValuesWith(RedisSerializationContext.SerializationPair
+//                        .fromSerializer(redisValueSerializer)
+//                );
+//
+//        return RedisCacheManager.builder(connectionFactory)
+//                .cacheDefaults(config)
+//                .build();
+//    }
+
+
+    /**
+     * 쿠폰 발급 Lua
+     */
     @Bean
     public RedisScript<Long> issueCouponScript(){
         DefaultRedisScript<Long> redisScript = new DefaultRedisScript<>();

--- a/coupon/src/main/java/com/high/coupon/infrastructure/persistence/redis/CouponCacheRedisRepositoryImpl.java
+++ b/coupon/src/main/java/com/high/coupon/infrastructure/persistence/redis/CouponCacheRedisRepositoryImpl.java
@@ -22,14 +22,15 @@ public class CouponCacheRedisRepositoryImpl implements CouponCachePort {
     private final RedisScript<Long> issueCouponScript;
 
     @Override
-    public Long tryIssueCoupon(UUID couponId, UUID userId, Integer totalQuantity) {
+    public Long tryIssueCoupon(UUID couponId, UUID userId, Integer totalQuantity, Long ttlSeconds) {
         String key = "coupon:" + couponId + ":users";
 
         return redisTemplate.execute(
                 issueCouponScript,
                 Collections.singletonList(key),
                 userId.toString(),
-                String.valueOf(totalQuantity)
+                String.valueOf(totalQuantity),
+                String.valueOf(ttlSeconds)
         );
     }
 }

--- a/coupon/src/main/java/com/high/coupon/presentation/CouponIssueController.java
+++ b/coupon/src/main/java/com/high/coupon/presentation/CouponIssueController.java
@@ -11,7 +11,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,16 +31,19 @@ public class CouponIssueController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-
-    /**
-     * todo: 테스트용 URL
-     */
-    @PostMapping("/{couponId}/issue/test")
-    public ResponseEntity<CouponIssueResponse> issueCouponTest(
-            @PathVariable UUID couponId,
-            @RequestParam UUID userId
-    ){
-        var response = couponIssueService.issueCoupon(couponId, userId);
-        return ResponseEntity.ok(response);
-    }
+//
+//    /**
+//     * todo: 테스트용 URL
+//     */
+//    @PostMapping("/{couponId}/issue/test")
+//    public ResponseEntity<CouponIssueResponse> issueCouponTest(
+//            @PathVariable UUID couponId,
+//            @RequestBody TestCouponRequest request // 아래 만든 record 사용
+//    ) {
+//        // 서비스 호출 (userId를 Body에서 꺼내서 넘김)
+//        var response = couponIssueService.issueCoupon(couponId, request.userId());
+//        return ResponseEntity.ok(response);
+//    }
+//
+//    public record TestCouponRequest(UUID userId) {}
 }

--- a/coupon/src/main/resources/application.yaml
+++ b/coupon/src/main/resources/application.yaml
@@ -9,6 +9,12 @@ spring:
         enabled: true
         service-id: config
 
+server:
+  tomcat:
+    threads:
+      max: 500 # 동시에 처리 가능한 HTTP 요청 쓰레드 수 설정
+    accept-count: 500 # 대기 가능한 요청 수
+
 management:
   endpoints:
     web:
@@ -30,3 +36,6 @@ logging:
     org.springframework.transaction: DEBUG
     org.hibernate.SQL: INFO
     org.hibernate.type.descriptor.sql: INFO
+    #com.zaxxer.hikari: DEBUG
+    #org.apache.coyote: DEBUG
+    #org.springframework.cache: TRACE

--- a/coupon/src/main/resources/scripts/issue_coupon.lua
+++ b/coupon/src/main/resources/scripts/issue_coupon.lua
@@ -2,6 +2,7 @@
     -- KEYS[1]: 쿠폰 발급 유저 목록 SET
     -- ARGV[1] = userId (UUID - String)
     -- ARGV[2] = 총 수량 (limit)
+    -- ARGV[3] = 만료 시간 (TTL)
 
     0 성공
     -1 실패: 수량 소진
@@ -19,13 +20,16 @@ end
 -- 2. 쿠폰 잔여 수량 조회 및 체크 (local - 지역 변수 선언) SET 0(1)
 -- 카운터를 별도로 관리하지 않고, 실제 발급된 유저 수가 곧 수량으로 체크
 local current_count = redis.call('SCARD',KEYS[1])
-
 -- 수량이 없거나, 0보다 작거나 같으면 발급 불가 (tonumber - 문자열로 들어온 argv를 숫자로 변환하는 함수)
 if tonumber(current_count) >= tonumber(ARGV[2]) then
     return -1 -- [결과] 쿠폰 수량 소진
 end
 
--- 3. 발급 확정 (SET에 추가)
+-- 3. 발급 확정 (SET에 추가) 및 메모리 TTL
 redis.call('SADD', KEYS[1], ARGV[1])
+
+if redis.call('TTL', KEYS[1]) == -1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[3]) -- 이벤트 종료일 + N일까지만 유지
+end
 
 return 0 -- [결과] 쿠폰 발급 성공


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #140 


## 📝 Description

1. **쿠폰 정보 Local Cache 적용**
사용자의 쿠폰 발급 요청 수마다 발생하는 Coupon 정보를 캐싱하여 반복적인 DB 조회를 제거하였습니다.

2. **Redis 발급 유저 데이터 메모리 관리**
계속해서 누적되는 Redis 메모리를 효율적으로 관리하기 위해 이벤트 종료일 + 여유 기간 (3일)을 계산하여 Redis Key 자동 만료 처리를 추가하였습니다.

## 🌐 Test Result

- 수백 건의 동시 요청 시에도 select문 한 번 생성되는 것 확인

<img width="1448" height="563" alt="스크린샷 2025-12-20 002107" src="https://github.com/user-attachments/assets/a32a2392-4d23-4733-b5f3-d1d0dbe91807" />

---

- Redis TTL 적용 확인 (1)
<img width="548" height="440" alt="스크린샷 2025-12-20 211800" src="https://github.com/user-attachments/assets/420d4dbe-8d64-42f2-980b-69665dfeee52" />

<br><br>

- Redis TTL 적용 확인 (2) - 60초로 임시 테스트 진행, 만료 확인

<img width="1346" height="440" alt="스크린샷 2025-12-20 212143" src="https://github.com/user-attachments/assets/31b4677c-a4b4-4c73-a35a-23941d92a110" />
<img width="1288" height="114" alt="스크린샷 2025-12-20 212156" src="https://github.com/user-attachments/assets/6c5b0f49-40a7-4e7e-8697-bca461545cd9" />

<br><br>

- 개선 효과
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/cc93ef0c-ef13-4810-916c-915f60e2d9d0" />


<!--StartFragment-->
지표 (Metric) | Kafka+DB 조회 (Before) | Local Cache 적용 (After) | 개선 효과 (Diff)
-- | -- | -- | --
Throughput (RPS) | 511.1 req/s | 534.8 req/s | 🔺 4.6% 증가
Avg Latency (평균) | 21.45 ms | 16.11 ms | ⚡ 24.9% 단축
P95 Latency (상위 5%) | 41.92 ms | 38.44 ms | ⚡ 8.3% 단축
Max Latency (최대 지연) | 177.04 ms | 92.85 ms | 🛡️ 47.6% 개선
Error Rate | 0% | 0% | 동일

<!--EndFragment-->





## 🔎 To Reviewer
- 계층 구조가 적절하게 이루어졌을 지
- 개선이 필요한 코드가 있을 지
