### PR TITLE
feat: 재고 차감/복원 이벤트 처리에 Retry & DLQ 구현

### DIFF
--- a/config/src/main/resources/config-repo/product-service.yml
+++ b/config/src/main/resources/config-repo/product-service.yml
@@ -37,18 +37,18 @@ spring:
       time-to-live: 5000
       cache-null-values: false
       use-key-prefix: true
-      key-prefix: product::
+      key-prefix: "product::" # 이 부분이 에러원인(""로 감싸줘야 함)
 
 redisson:
   mode: single
   single:
     address: redis://localhost:6379
-#  mode: cluster # 나중에 K8s로 배포를 한다고 가정하면 필요한 코드
-#  cluster:
-#    nodes:
-#      - redis://redis-0.redis:6379
-#      - redis://redis-1.redis:6379
-#      - redis://redis-2.redis:6379
+  #  mode: cluster # 나중에 K8s로 배포를 한다고 가정하면 필요한 코드
+  #  cluster:
+  #    nodes:
+  #      - redis://redis-0.redis:6379
+  #      - redis://redis-1.redis:6379
+  #      - redis://redis-2.redis:6379
   lock:
     wait-time: 5s
     lease-time: 15s

--- a/product/src/main/java/com/high/product/ProductApplication.java
+++ b/product/src/main/java/com/high/product/ProductApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableFeignClients
 @SpringBootApplication
+@EnableScheduling
 // 공통 라이브러리 스캔 범위 추가
 @ComponentScan(basePackages = {"com.high.product", "com.library.module"})
 public class ProductApplication {

--- a/product/src/main/java/com/high/product/application/dto/kafka/dlq/StockDeductionDlqMessage.java
+++ b/product/src/main/java/com/high/product/application/dto/kafka/dlq/StockDeductionDlqMessage.java
@@ -1,0 +1,20 @@
+package com.high.product.application.dto.kafka.dlq;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StockDeductionDlqMessage(
+	UUID sagaId,
+	UUID orderId,
+	UUID userId,
+
+	String originalTopic,
+	int retryCount,
+	String exceptionType,
+	String exceptionMessage,
+	String stackTrace,
+
+	String consumerGroup,
+	LocalDateTime failedAt
+) {
+}

--- a/product/src/main/java/com/high/product/application/dto/kafka/dlq/StockRestoreDlqMessage.java
+++ b/product/src/main/java/com/high/product/application/dto/kafka/dlq/StockRestoreDlqMessage.java
@@ -1,0 +1,20 @@
+package com.high.product.application.dto.kafka.dlq;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StockRestoreDlqMessage(
+	UUID sagaId,
+	UUID orderId,
+	UUID userId,
+
+	String originalTopic,
+	int retryCount,
+	String exceptionType,
+	String exceptionMessage,
+	String stackTrace,
+
+	String consumerGroup,
+	LocalDateTime failedAt
+) {
+}

--- a/product/src/main/java/com/high/product/application/port/SagaDeduplicationPort.java
+++ b/product/src/main/java/com/high/product/application/port/SagaDeduplicationPort.java
@@ -6,5 +6,7 @@ public interface SagaDeduplicationPort {
 
 	boolean tryProcess(String key, long ttlSeconds);
 
+	void save(String key, long ttlSeconds);
+
 	void remove(String key);
 }

--- a/product/src/main/java/com/high/product/application/service/StockDeductionService.java
+++ b/product/src/main/java/com/high/product/application/service/StockDeductionService.java
@@ -1,9 +1,11 @@
 package com.high.product.application.service;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.product.application.dto.external.OrderDetailResponse;
 import com.high.product.application.dto.external.OrderItemResponse;
 import com.high.product.application.dto.kafka.failure.StockDeductionFailMessage;
@@ -13,11 +15,12 @@ import com.high.product.application.exception.ProductException;
 import com.high.product.application.port.DistributedLockPort;
 import com.high.product.application.port.OrderQueryPort;
 import com.high.product.application.port.RedisCacheEvictPort;
-import com.high.product.application.port.StockPublisherPort;
+import com.high.product.domain.model.KafkaOutbox;
+import com.high.product.domain.repository.KafkaOutboxRepository;
+import com.high.product.application.port.SagaDeduplicationPort;
 import com.high.product.domain.model.Product_Stock;
 import com.high.product.domain.repository.StockRepository;
 import com.high.product.exception.ProductErrorCode;
-import com.high.product.application.port.SagaDeduplicationPort;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,10 +32,11 @@ public class StockDeductionService {
 
 	private final OrderQueryPort orderQueryPort;
 	private final StockRepository stockRepository;
-	private final StockPublisherPort stockPublisherPort;
 	private final DistributedLockPort distributedLockPort;
 	private final SagaDeduplicationPort sagaDeduplicationPort;
 	private final RedisCacheEvictPort stockCacheEvictPort;
+	private final KafkaOutboxRepository kafkaOutboxRepository;
+	private final ObjectMapper objectMapper;
 
 	public void handleStockDeduction(StockDeductionCommandRequest request) {
 
@@ -54,25 +58,23 @@ public class StockDeductionService {
 			// 멱등성 체크 (이미 완료된 saga)
 			if (sagaDeduplicationPort.exists("success:" + request.sagaId())) {
 				log.info("이미 성공 처리된 sagaId={}, success 재전송", request.sagaId());
-				stockPublisherPort.publishSuccess(
-					new StockDeductionSuccessMessage(
-						request.sagaId(),
-						request.orderId(),
-						request.userId()
-					)
+
+				// 아웃박스 PENDING으로 저장 (재전송)
+				saveOutboxEvent(
+					"stock-deduction-success",
+					new StockDeductionSuccessMessage(request.sagaId(), request.orderId(), request.userId())
 				);
 				return;
 			}
 
 			if (sagaDeduplicationPort.exists("fail:" + request.sagaId())) {
 				log.info("이미 실패 처리된 sagaId={}, fail 재전송", request.sagaId());
-				stockPublisherPort.publishFail(
-					new StockDeductionFailMessage(
-						request.sagaId(),
-						request.orderId(),
-						"이미 실패 처리된 saga",
-						request.userId()
-					)
+
+				// 아웃박스 PENDING으로 저장 (재전송)
+				saveOutboxEvent(
+					"stock-deduction-fail",
+					new StockDeductionFailMessage(request.sagaId(), request.orderId(), "이미 실패 처리된 saga",
+						request.userId())
 				);
 				return;
 			}
@@ -102,12 +104,10 @@ public class StockDeductionService {
 				sagaDeduplicationPort.tryProcess("success:" + request.sagaId(), 600);
 				sagaDeduplicationPort.remove("processing:" + request.sagaId());
 
-				stockPublisherPort.publishSuccess(
-					new StockDeductionSuccessMessage(
-						request.sagaId(),
-						request.orderId(),
-						request.userId()
-					)
+				// 아웃박스 PENDING으로 저장
+				saveOutboxEvent(
+					"stock-deduction-success",
+					new StockDeductionSuccessMessage(request.sagaId(), request.orderId(), request.userId())
 				);
 
 				log.info("재고 차감 성공 sagaId={}", request.sagaId());
@@ -117,13 +117,11 @@ public class StockDeductionService {
 				sagaDeduplicationPort.tryProcess("fail:" + request.sagaId(), 600);
 				sagaDeduplicationPort.remove("processing:" + request.sagaId());
 
-				stockPublisherPort.publishFail(
-					new StockDeductionFailMessage(
-						request.sagaId(),
-						request.orderId(),
-						ex.getMessage(),
-						request.userId()
-					)
+				// 아웃박스 PENDING으로 저장 (실패 이벤트)
+				saveOutboxEvent(
+					"stock-deduction-fail",
+					new StockDeductionFailMessage(request.sagaId(), request.orderId(), ex.getMessage(),
+						request.userId())
 				);
 
 				log.error("재고 차감 실패 sagaId={}", request.sagaId(), ex);
@@ -133,5 +131,31 @@ public class StockDeductionService {
 				sagaDeduplicationPort.remove("processing:" + request.sagaId());
 			}
 		});
+	}
+
+	// 아웃박스 저장 헬퍼 메서드
+	private void saveOutboxEvent(String topic, Object message) {
+		try {
+			String payload = objectMapper.writeValueAsString(message);
+			KafkaOutbox outbox = KafkaOutbox.builder()
+				.topic(topic)
+				.messageKey(message instanceof StockDeductionSuccessMessage s ? String.valueOf(s.sagaId()) :
+					message instanceof StockDeductionFailMessage f ? String.valueOf(f.sagaId()) :
+						UUID.randomUUID().toString())
+				.payload(payload)
+				.status("PENDING")
+				.sagaId(message instanceof StockDeductionSuccessMessage s ? s.sagaId() :
+					message instanceof StockDeductionFailMessage f ? f.sagaId() : null)
+				.orderId(message instanceof StockDeductionSuccessMessage s ? s.orderId() :
+					message instanceof StockDeductionFailMessage f ? f.orderId() : null)
+				.userId(message instanceof StockDeductionSuccessMessage s ? s.userId() :
+					message instanceof StockDeductionFailMessage f ? f.userId() : null)
+				.build();
+
+			kafkaOutboxRepository.save(outbox);
+		} catch (Exception e) {
+			log.error("Kafka Outbox 저장 실패", e);
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/product/src/main/java/com/high/product/application/service/StockDeductionService.java
+++ b/product/src/main/java/com/high/product/application/service/StockDeductionService.java
@@ -18,6 +18,7 @@ import com.high.product.domain.model.Product_Stock;
 import com.high.product.domain.repository.StockRepository;
 import com.high.product.exception.ProductErrorCode;
 import com.high.product.application.port.SagaDeduplicationPort;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -127,6 +128,9 @@ public class StockDeductionService {
 
 				log.error("재고 차감 실패 sagaId={}", request.sagaId(), ex);
 				throw ex;
+			} finally {
+				// processing 키 제거 (재처리 가능하도록)
+				sagaDeduplicationPort.remove("processing:" + request.sagaId());
 			}
 		});
 	}

--- a/product/src/main/java/com/high/product/application/service/StockRestoreService.java
+++ b/product/src/main/java/com/high/product/application/service/StockRestoreService.java
@@ -1,9 +1,11 @@
 package com.high.product.application.service;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.product.application.dto.external.OrderDetailResponse;
 import com.high.product.application.dto.external.OrderItemResponse;
 import com.high.product.application.dto.kafka.failure.StockRestoreFailMessage;
@@ -13,11 +15,12 @@ import com.high.product.application.exception.ProductException;
 import com.high.product.application.port.DistributedLockPort;
 import com.high.product.application.port.OrderQueryPort;
 import com.high.product.application.port.RedisCacheEvictPort;
-import com.high.product.application.port.StockPublisherPort;
+import com.high.product.domain.model.KafkaOutbox;
+import com.high.product.domain.repository.KafkaOutboxRepository;
+import com.high.product.application.port.SagaDeduplicationPort;
 import com.high.product.domain.model.Product_Stock;
 import com.high.product.domain.repository.StockRepository;
 import com.high.product.exception.ProductErrorCode;
-import com.high.product.application.port.SagaDeduplicationPort;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,10 +32,11 @@ public class StockRestoreService {
 
 	private final OrderQueryPort orderQueryPort;
 	private final StockRepository stockRepository;
-	private final StockPublisherPort stockPublisherPort;
 	private final DistributedLockPort distributedLockPort;
 	private final SagaDeduplicationPort sagaDeduplicationPort;
 	private final RedisCacheEvictPort stockCacheEvictPort;
+	private final KafkaOutboxRepository kafkaOutboxRepository;
+	private final ObjectMapper objectMapper;
 
 	public void handleStockRestore(StockRestoreCommandRequest request) {
 
@@ -54,12 +58,11 @@ public class StockRestoreService {
 			// 이미 성공 처리된 복원
 			if (sagaDeduplicationPort.exists("restore:success:" + request.sagaId())) {
 				log.info("이미 복원 성공 sagaId={}, success 재전송", request.sagaId());
-				stockPublisherPort.publishSuccess(
-					new StockRestoreSuccessMessage(
-						request.sagaId(),
-						request.orderId(),
-						request.userId()
-					)
+
+				// 아웃박스 PENDING으로 저장 (재전송)
+				saveOutboxEvent(
+					"stock-restore-success",
+					new StockRestoreSuccessMessage(request.sagaId(), request.orderId(), request.userId())
 				);
 				return;
 			}
@@ -67,13 +70,12 @@ public class StockRestoreService {
 			// 이미 실패 처리된 복원
 			if (sagaDeduplicationPort.exists("restore:fail:" + request.sagaId())) {
 				log.info("이미 복원 실패 sagaId={}, fail 재전송", request.sagaId());
-				stockPublisherPort.publishFail(
-					new StockRestoreFailMessage(
-						request.sagaId(),
-						request.orderId(),
-						"이미 실패 처리된 복원 saga",
-						request.userId()
-					)
+
+				// 아웃박스 PENDING으로 저장 (재전송)
+				saveOutboxEvent(
+					"stock-restore-fail",
+					new StockRestoreFailMessage(request.sagaId(), request.orderId(), "이미 실패 처리된 복원 saga",
+						request.userId())
 				);
 				return;
 			}
@@ -92,7 +94,6 @@ public class StockRestoreService {
 						.orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
 					stock.increase(item.quantity());
-
 				}
 
 				// DB 트랜잭션 이후 캐시 무효화
@@ -104,12 +105,10 @@ public class StockRestoreService {
 				sagaDeduplicationPort.tryProcess("restore:success:" + request.sagaId(), 600);
 				sagaDeduplicationPort.remove("processing:" + request.sagaId());
 
-				stockPublisherPort.publishSuccess(
-					new StockRestoreSuccessMessage(
-						request.sagaId(),
-						request.orderId(),
-						request.userId()
-					)
+				// 아웃박스 PENDING으로 저장
+				saveOutboxEvent(
+					"stock-restore-success",
+					new StockRestoreSuccessMessage(request.sagaId(), request.orderId(), request.userId())
 				);
 
 				log.info("재고 복원 성공 sagaId={}", request.sagaId());
@@ -119,13 +118,10 @@ public class StockRestoreService {
 				sagaDeduplicationPort.tryProcess("restore:fail:" + request.sagaId(), 600);
 				sagaDeduplicationPort.remove("processing:" + request.sagaId());
 
-				stockPublisherPort.publishFail(
-					new StockRestoreFailMessage(
-						request.sagaId(),
-						request.orderId(),
-						ex.getMessage(),
-						request.userId()
-					)
+				// 아웃박스 PENDING으로 저장 (실패 이벤트)
+				saveOutboxEvent(
+					"stock-restore-fail",
+					new StockRestoreFailMessage(request.sagaId(), request.orderId(), ex.getMessage(), request.userId())
 				);
 
 				log.error("재고 복원 실패 sagaId={}", request.sagaId(), ex);
@@ -135,5 +131,31 @@ public class StockRestoreService {
 				sagaDeduplicationPort.remove("processing:" + request.sagaId());
 			}
 		});
+	}
+
+	// 아웃박스 저장 헬퍼 메서드
+	private void saveOutboxEvent(String topic, Object message) {
+		try {
+			String payload = objectMapper.writeValueAsString(message);
+			KafkaOutbox outbox = KafkaOutbox.builder()
+				.topic(topic)
+				.messageKey(message instanceof StockRestoreSuccessMessage s ? String.valueOf(s.sagaId()) :
+					message instanceof StockRestoreFailMessage f ? String.valueOf(f.sagaId()) :
+						UUID.randomUUID().toString())
+				.payload(payload)
+				.status("PENDING")
+				.sagaId(message instanceof StockRestoreSuccessMessage s ? s.sagaId() :
+					message instanceof StockRestoreFailMessage f ? f.sagaId() : null)
+				.orderId(message instanceof StockRestoreSuccessMessage s ? s.orderId() :
+					message instanceof StockRestoreFailMessage f ? f.orderId() : null)
+				.userId(message instanceof StockRestoreSuccessMessage s ? s.userId() :
+					message instanceof StockRestoreFailMessage f ? f.userId() : null)
+				.build();
+
+			kafkaOutboxRepository.save(outbox);
+		} catch (Exception e) {
+			log.error("Kafka Outbox 저장 실패", e);
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/product/src/main/java/com/high/product/domain/model/KafkaOutbox.java
+++ b/product/src/main/java/com/high/product/domain/model/KafkaOutbox.java
@@ -1,0 +1,65 @@
+package com.high.product.domain.model;
+
+import java.util.UUID;
+
+import com.library.jpa.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_kafka_outbox")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class KafkaOutbox extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	private String topic;
+	private String messageKey;
+
+	@Lob
+	private String payload;
+
+	private String status; // PENDING, SENT, FAILED
+	private int retryCount;
+
+	private UUID sagaId;
+	private UUID orderId;
+	private UUID userId;
+
+	public void markSent() {
+		this.status = "SENT";
+	}
+
+	public void markFailed() {
+		this.status = "FAILED";
+	}
+
+	public void increaseRetry() {
+		this.retryCount++;
+	}
+
+	public KafkaOutbox(String topic, String payload, String status, UUID sagaId, UUID orderId, UUID userId) {
+		this.topic = topic;
+		this.payload = payload;
+		this.status = status;
+		this.sagaId = sagaId;
+		this.orderId = orderId;
+		this.userId = userId;
+	}
+}

--- a/product/src/main/java/com/high/product/domain/repository/KafkaOutboxRepository.java
+++ b/product/src/main/java/com/high/product/domain/repository/KafkaOutboxRepository.java
@@ -1,0 +1,14 @@
+package com.high.product.domain.repository;
+
+import java.util.List;
+
+import com.high.product.domain.model.KafkaOutbox;
+
+public interface KafkaOutboxRepository {
+
+	List<KafkaOutbox> findTop100ByStatusOrderByCreatedAtAsc(String status);
+
+	KafkaOutbox save(KafkaOutbox outbox);
+
+	void markAsSent(KafkaOutbox outbox);
+}

--- a/product/src/main/java/com/high/product/infrastructure/kafka/KafkaConfig.java
+++ b/product/src/main/java/com/high/product/infrastructure/kafka/KafkaConfig.java
@@ -2,20 +2,25 @@ package com.high.product.infrastructure.kafka;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.*;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurationSupport;
+import org.springframework.util.backoff.ExponentialBackOff;
 
 @EnableKafka
 @Configuration
-public class KafkaConfig {
+public class KafkaConfig extends RetryTopicConfigurationSupport {
 
 	@Bean
 	public ProducerFactory<String, String> producerFactory() {
@@ -24,10 +29,9 @@ public class KafkaConfig {
 		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 
-		// 멱등성
 		props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
 		props.put(ProducerConfig.ACKS_CONFIG, "all");
-		props.put(ProducerConfig.RETRIES_CONFIG, Integer.MAX_VALUE);
+		props.put(ProducerConfig.RETRIES_CONFIG, 3);
 		props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
 
 		return new DefaultKafkaProducerFactory<>(props);
@@ -35,8 +39,7 @@ public class KafkaConfig {
 
 	@Bean
 	public KafkaTemplate<String, String> kafkaTemplate() {
-		KafkaTemplate<String, String> template = new KafkaTemplate<>(producerFactory());
-		return template;
+		return new KafkaTemplate<>(producerFactory());
 	}
 
 	@Bean
@@ -46,6 +49,12 @@ public class KafkaConfig {
 		props.put(ConsumerConfig.GROUP_ID_CONFIG, "product-service-group");
 		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+		// @RetryableTopic는 예외 throw 시 offset commit을 지연하므로 비활성화
+		props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+		// 처음 시작 시 가장 앞부터 읽음
+		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
 		return new DefaultKafkaConsumerFactory<>(props);
 	}
 
@@ -54,6 +63,28 @@ public class KafkaConfig {
 		ConcurrentKafkaListenerContainerFactory<String, String> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
 		factory.setConsumerFactory(consumerFactory());
+
+		// offset commit 시점 제어: 이미 처리된 건은 확실히 커밋(RECORD, 메시지 별로 즉시 반영)
+		factory.getContainerProperties()
+			.setAckMode(ContainerProperties.AckMode.RECORD);
+
 		return factory;
+	}
+
+	/**
+	 *
+	 * - attempts = 3: 첫 시도 포함 총 3번 시도
+	 * - backoff: 1초 시작, 2배씩 증가, 최대 10초 대기 (지수 백오프)
+	 * - dltTopicSuffix: 실패 시 '-dlq' 토픽으로 이동, KafkaConfig 설정
+	 */
+	@Bean
+	public RetryTopicConfiguration retryTopicConfig(KafkaTemplate<String, String> kafkaTemplate) {
+		return RetryTopicConfigurationBuilder
+			// .newInstance()만 사용하면 모든 @RetryableTopic에 적용
+			.newInstance()
+			.maxAttempts(3)
+			.exponentialBackoff(1000, 2.0, 10000)
+			.dltSuffix("-dlq")
+			.create(kafkaTemplate);
 	}
 }

--- a/product/src/main/java/com/high/product/infrastructure/kafka/KafkaConfig.java
+++ b/product/src/main/java/com/high/product/infrastructure/kafka/KafkaConfig.java
@@ -7,16 +7,21 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
-import org.springframework.kafka.core.*;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
-import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationSupport;
-import org.springframework.util.backoff.ExponentialBackOff;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @EnableKafka
 @Configuration
@@ -86,5 +91,18 @@ public class KafkaConfig extends RetryTopicConfigurationSupport {
 			.exponentialBackoff(1000, 2.0, 10000)
 			.dltSuffix("-dlq")
 			.create(kafkaTemplate);
+	}
+
+	/**
+	 * RetryTopicConfigurationSupport를 상속받을 때 필요한 스케줄러 설정
+	 * 지연 재시도(Backoff) 시점을 관리하기 위해 반드시 필요
+	 */
+	@Bean
+	public TaskScheduler taskScheduler() {
+		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+		scheduler.setPoolSize(2);
+		scheduler.setThreadNamePrefix("kafka-retry-scheduler-");
+		scheduler.initialize();
+		return scheduler;
 	}
 }

--- a/product/src/main/java/com/high/product/infrastructure/kafka/consumer/StockDeductionKafkaConsumer.java
+++ b/product/src/main/java/com/high/product/infrastructure/kafka/consumer/StockDeductionKafkaConsumer.java
@@ -1,15 +1,29 @@
 package com.high.product.infrastructure.kafka.consumer;
 
-import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.stereotype.Component;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.high.product.application.dto.kafka.dlq.StockDeductionDlqMessage;
 import com.high.product.application.dto.kafka.request.StockDeductionCommandRequest;
 import com.high.product.application.service.StockDeductionService;
+import com.high.product.domain.model.KafkaOutbox;
+import com.high.product.domain.repository.KafkaOutboxRepository;
 import com.high.product.infrastructure.context.MessageContext;
+import com.high.product.application.port.SagaDeduplicationPort;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.kafka.annotation.DltHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -18,21 +32,121 @@ public class StockDeductionKafkaConsumer {
 
 	private final StockDeductionService stockDeductionService;
 	private final ObjectMapper objectMapper;
+	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final SagaDeduplicationPort sagaDeduplicationPort;
+	private final KafkaOutboxRepository kafkaOutboxRepository;
 
-	@KafkaListener(topics = "stock-deduction-request")
-	public void consumeStockDeductionRequest(String message) {
+	/**
+	 * - attempts = 3: 첫 시도 포함 총 3번 시도
+	 * - backoff 제거 (즉시 재시도)
+	 * - dltTopicSuffix: 실패 시 '-dlq' 토픽으로 이동
+	 */
+	@RetryableTopic
+	@KafkaListener(
+		// 재고 차감 토픽과 재시도용 토픽을 모두 구독하도록 추가
+		topics = "stock-deduction-request",
+		groupId = "product-service-group"
+	)
+	public void consume(String message) throws Exception {
+		log.info("Received stock deduction message: {}", message);
+
+		// 메시지 역직렬화
+		StockDeductionCommandRequest request =
+			objectMapper.readValue(message, StockDeductionCommandRequest.class);
+
+		// Kafka 메시지 기반 ThreadLocal 세팅
+		MessageContext.set(request.userId(), "USER");
+
 		try {
-			StockDeductionCommandRequest request = objectMapper.readValue(message, StockDeductionCommandRequest.class);
+			// 멱등성 체크: 이미 처리된 saga 재처리 방지
+			if (sagaDeduplicationPort.exists("success:" + request.sagaId()) ||
+				sagaDeduplicationPort.exists("fail:" + request.sagaId())) {
+				log.info("이미 처리된 sagaId={}, 재처리 스킵", request.sagaId());
+				return;
+			}
 
-			// Kafka 메시지 기반 ThreadLocal 세팅
-			MessageContext.set(request.userId(), "USER");
-
+			// 재고 차감 서비스 호출
 			stockDeductionService.handleStockDeduction(request);
+			log.info(
+				"재고 차감 이벤트 성공 sagaId={} orderId={} userId={}",
+				request.sagaId(),
+				request.orderId(),
+				request.userId()
+			);
+
 		} catch (Exception e) {
-			log.error("[KafkaConsumer] stock-deduction-request 메시지 처리 실패: {}", message, e);
+			log.error("재고 차감 이벤트 처리 도중 예외 발생: {}", e.getMessage());
+			// 예외를 다시 던져야 @RetryableTopic이 감지하여 재시도 스케줄링을 진행함
+			throw e;
+
 		} finally {
 			// 처리 후 ThreadLocal 정리
 			MessageContext.clear();
 		}
+	}
+
+	// 재시도 후 최종 실패 시, DLQ로 이동 → Outbox FAILED 상태 저장
+	@DltHandler
+	@Transactional
+	public void handleDlt(
+		String message,
+		Exception e,
+		@Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+		@Header(KafkaHeaders.OFFSET) long offset,
+		@Header(KafkaHeaders.GROUP_ID) String consumerGroup
+	) {
+		try {
+			String stackTrace = getStackTraceAsString(e);
+			StockDeductionCommandRequest request =
+				objectMapper.readValue(message, StockDeductionCommandRequest.class);
+
+			// DLQ 메시지 로깅
+			StockDeductionDlqMessage dlqMessage = new StockDeductionDlqMessage(
+				request.sagaId(),
+				request.orderId(),
+				request.userId(),
+				topic,
+				0, // 재시도 횟수는 @RetryableTopic에 의해 이미 수행됨
+				e.getClass().getSimpleName(),
+				e.getMessage(),
+				stackTrace,
+				consumerGroup,
+				LocalDateTime.now()
+			);
+
+			log.error("[DLQ] 재고 차감 최종 재시도 실패: {}", dlqMessage);
+
+			// 멱등성 보관소에 최종 실패 기록 추가 (재처리 방지)
+			sagaDeduplicationPort.save("fail:" + request.sagaId(), 600);
+
+			// 새로 추가: DLQ 처리 시 Outbox FAILED 저장
+			try {
+				String payload = objectMapper.writeValueAsString(request);
+				KafkaOutbox outbox = KafkaOutbox.builder()
+					.topic("stock-deduction-dlq")
+					.payload(payload)
+					.status("FAILED")
+					.sagaId(request.sagaId())
+					.orderId(request.orderId())
+					.userId(request.userId())
+					.build();
+				kafkaOutboxRepository.save(outbox);
+				log.info("[DLQ][Outbox] FAILED 메시지 저장 sagaId={}", request.sagaId());
+			} catch (Exception exOutbox) {
+				log.error("[DLQ][Outbox] FAILED 메시지 저장 실패 sagaId={}", request.sagaId(), exOutbox);
+			}
+
+		} catch (Exception ex) {
+			log.error("DLQ 메시지 생성 실패: {}", ex.getMessage(), ex);
+		}
+	}
+
+	private String getStackTraceAsString(Throwable throwable) {
+		if (throwable == null)
+			return "";
+		StringWriter sw = new StringWriter();
+		PrintWriter pw = new PrintWriter(sw);
+		throwable.printStackTrace(pw);
+		return sw.toString();
 	}
 }

--- a/product/src/main/java/com/high/product/infrastructure/kafka/consumer/StockRestoreKafkaConsumer.java
+++ b/product/src/main/java/com/high/product/infrastructure/kafka/consumer/StockRestoreKafkaConsumer.java
@@ -1,11 +1,25 @@
 package com.high.product.infrastructure.kafka.consumer;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+
+import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.high.product.application.dto.kafka.dlq.StockRestoreDlqMessage;
 import com.high.product.application.dto.kafka.request.StockRestoreCommandRequest;
 import com.high.product.application.service.StockRestoreService;
+import com.high.product.domain.model.KafkaOutbox;
+import com.high.product.domain.repository.KafkaOutboxRepository;
+import com.high.product.application.port.SagaDeduplicationPort;
 import com.high.product.infrastructure.context.MessageContext;
 
 import lombok.RequiredArgsConstructor;
@@ -18,21 +32,120 @@ public class StockRestoreKafkaConsumer {
 
 	private final StockRestoreService stockRestoreService;
 	private final ObjectMapper objectMapper;
+	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final SagaDeduplicationPort sagaDeduplicationPort;
+	private final KafkaOutboxRepository kafkaOutboxRepository;
 
-	@KafkaListener(topics = "stock-restore-request")
-	public void consumeStockRestoreRequest(String message) {
+	/**
+	 *
+	 * - attempts = 3: 첫 시도 포함 총 3번 시도
+	 * - backoff: 1초 시작, 2배씩 증가, 최대 10초 대기 (지수 백오프)
+	 * - dltTopicSuffix: 실패 시 '-dlq' 토픽으로 이동, KafkaConfig 설정
+	 */
+	@RetryableTopic
+	@KafkaListener(
+		topics = "stock-restore-request",
+		groupId = "product-service-group"
+	)
+	public void consume(String message) throws Exception {
+		log.info("Received stock restore message: {}", message);
+
+		// 메시지 역직렬화
+		StockRestoreCommandRequest request =
+			objectMapper.readValue(message, StockRestoreCommandRequest.class);
+
+		// 컨텍스트 설정 (ThreadLocal)
+		MessageContext.set(request.userId(), "USER");
+
 		try {
-			StockRestoreCommandRequest request = objectMapper.readValue(message, StockRestoreCommandRequest.class);
+			// 멱등성 체크: 이미 처리된 saga 재처리 방지
+			if (sagaDeduplicationPort.exists("success:" + request.sagaId()) ||
+				sagaDeduplicationPort.exists("fail:" + request.sagaId())) {
+				log.info("이미 처리된 sagaId={}, 재처리 스킵", request.sagaId());
+				return;
+			}
 
-			// Kafka 메시지 기반 ThreadLocal 세팅
-			MessageContext.set(request.userId(), "USER");
-
+			// 재고 복구 서비스 호출
 			stockRestoreService.handleStockRestore(request);
+			log.info(
+				"재고 복구 이벤트 성공 후 sagaId={} orderId={} ,userId={}",
+				request.sagaId(),
+				request.orderId(),
+				request.userId()
+			);
+
 		} catch (Exception e) {
-			log.error("[KafkaConsumer] stock-restore-request 메시지 처리 실패: {}", message, e);
+			log.error("재고 복구 이벤트 처리 도중 예외 발생: {}", e.getMessage());
+			// 예외를 다시 던져야 @RetryableTopic이 감지하여 재시도 스케줄링을 진행함
+			throw e;
+
 		} finally {
-			// 처리 후 ThreadLocal 정리
+			// ThreadLocal 자원 해제
 			MessageContext.clear();
 		}
+	}
+
+	// 재시도 최종 실패 시, 해당 이벤트 DLQ로 이동
+	@DltHandler
+	@Transactional
+	public void handleDlt(String message,
+		Exception e,
+		@Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+		@Header(KafkaHeaders.OFFSET) long offset,
+		@Header(KafkaHeaders.GROUP_ID) String consumerGroup) {
+
+		try {
+
+			String stackTrace = getStackTraceAsString(e);
+
+			StockRestoreCommandRequest request = objectMapper.readValue(message, StockRestoreCommandRequest.class);
+
+			StockRestoreDlqMessage dlqMessage = new StockRestoreDlqMessage(
+				request.sagaId(),
+				request.orderId(),
+				request.userId(),
+				topic,
+				0, // 재시도 횟수는 @RetryableTopic에 의해 수행됨
+				e.getClass().getSimpleName(),
+				e.getMessage(),
+				stackTrace,
+				consumerGroup,
+				LocalDateTime.now()
+			);
+			// Todo: 운영팀 알림(Slack 등)
+			log.error("[DLQ] 재고 복구 최종 재시도 실패, DLQ로 이동: {}", dlqMessage);
+
+			// 멱등성 보관소에 최종 실패 기록 (30일 보관)
+			sagaDeduplicationPort.save("fail:" + request.sagaId(), 86400 * 30);
+
+			// 아웃박스 테이블에 최종 실패 상태 저장
+			try {
+				String payload = objectMapper.writeValueAsString(request);
+				KafkaOutbox outbox = KafkaOutbox.builder()
+					.topic("stock-restore-dlq")
+					.payload(payload)
+					.status("FAILED")
+					.sagaId(request.sagaId())
+					.orderId(request.orderId())
+					.userId(request.userId())
+					.build();
+				kafkaOutboxRepository.save(outbox);
+				log.info("[DLQ][Outbox] 재고 복구 FAILED 메시지 저장 완료 sagaId={}", request.sagaId());
+			} catch (Exception exOutbox) {
+				log.error("[DLQ][Outbox] FAILED 메시지 저장 실패 sagaId={}", request.sagaId(), exOutbox);
+			}
+
+		} catch (Exception ex) {
+			log.error("DLQ 메시지 생성 실패: {}", ex.getMessage(), ex);
+		}
+	}
+
+	private String getStackTraceAsString(Throwable throwable) {
+		if (throwable == null)
+			return "";
+		StringWriter sw = new StringWriter();
+		PrintWriter pw = new PrintWriter(sw);
+		throwable.printStackTrace(pw);
+		return sw.toString();
 	}
 }

--- a/product/src/main/java/com/high/product/infrastructure/kafka/producer/KafkaOutboxPublisher.java
+++ b/product/src/main/java/com/high/product/infrastructure/kafka/producer/KafkaOutboxPublisher.java
@@ -1,0 +1,42 @@
+package com.high.product.infrastructure.kafka.producer;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.high.product.domain.model.KafkaOutbox;
+import com.high.product.domain.repository.KafkaOutboxRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaOutboxPublisher {
+
+	private final KafkaOutboxRepository kafkaOutboxRepository;
+	private final ProductKafkaPublisher kafkaPublisher;
+
+	@Scheduled(fixedDelay = 5000)
+	@Transactional
+	public void publishPendingMessages() {
+		List<KafkaOutbox> pending = kafkaOutboxRepository.findTop100ByStatusOrderByCreatedAtAsc("PENDING");
+		for (KafkaOutbox outbox : pending) {
+			try {
+				kafkaPublisher.send(outbox.getTopic(), outbox.getMessageKey(), outbox.getPayload());
+				kafkaOutboxRepository.markAsSent(outbox);
+				log.info("KafkaOutbox 발행 완료: {}", outbox.getId());
+			} catch (Exception e) {
+				outbox.increaseRetry();
+				if (outbox.getRetryCount() >= 3) {
+					outbox.markFailed();
+				}
+				kafkaOutboxRepository.save(outbox);
+				log.error("KafkaOutbox 발행 실패: {}", outbox.getId(), e);
+			}
+		}
+	}
+}

--- a/product/src/main/java/com/high/product/infrastructure/kafka/producer/KafkaPublisherAdapter.java
+++ b/product/src/main/java/com/high/product/infrastructure/kafka/producer/KafkaPublisherAdapter.java
@@ -1,20 +1,30 @@
 package com.high.product.infrastructure.kafka.producer;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.high.product.application.dto.kafka.failure.StockRestoreFailMessage;
 import com.high.product.application.dto.kafka.success.StockRestoreSuccessMessage;
 import com.high.product.application.port.StockPublisherPort;
 import com.high.product.application.dto.kafka.failure.StockDeductionFailMessage;
 import com.high.product.application.dto.kafka.success.StockDeductionSuccessMessage;
+import com.high.product.domain.model.KafkaOutbox;
+import com.high.product.domain.repository.KafkaOutboxRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KafkaPublisherAdapter implements StockPublisherPort {
 
 	private final ProductKafkaPublisher kafkaPublisher;
+	private final KafkaOutboxRepository kafkaOutboxRepository;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	public void publishSuccess(StockDeductionSuccessMessage message) {
@@ -23,6 +33,11 @@ public class KafkaPublisherAdapter implements StockPublisherPort {
 			String.valueOf(message.sagaId()),
 			message
 		);
+
+		saveOutbox(
+			"stock-deduction-success",
+			message.sagaId(), message.orderId(),
+			message.userId(), message);
 	}
 
 	@Override
@@ -32,6 +47,11 @@ public class KafkaPublisherAdapter implements StockPublisherPort {
 			String.valueOf(message.sagaId()),
 			message
 		);
+
+		saveOutbox("stock-deduction-fail",
+			message.sagaId(), message.orderId(),
+			message.userId(),
+			message);
 	}
 
 	@Override
@@ -41,6 +61,11 @@ public class KafkaPublisherAdapter implements StockPublisherPort {
 			String.valueOf(message.sagaId()),
 			message
 		);
+
+		saveOutbox("stock-restore-success",
+			message.sagaId(), message.orderId(),
+			message.userId(),
+			message);
 	}
 
 	@Override
@@ -50,5 +75,41 @@ public class KafkaPublisherAdapter implements StockPublisherPort {
 			String.valueOf(message.sagaId()),
 			message
 		);
+
+		saveOutbox("stock-restore-fail",
+			message.sagaId(),
+			message.orderId(),
+			message.userId(),
+			message);
+
+	}
+
+	// 아웃박스 경유 발행용 메서드
+	public void saveOutbox(String topic, UUID sagaId, UUID orderId, UUID userId, Object message) {
+		try {
+			// 객체를 JSON 문자열로 변환
+			String jsonPayload = objectMapper.writeValueAsString(message);
+
+			KafkaOutbox outbox = KafkaOutbox.builder()
+				.topic(topic)
+				.messageKey(sagaId.toString())
+				.payload(jsonPayload)
+				.status("PENDING")
+				.retryCount(0)
+				.sagaId(sagaId)
+				.orderId(orderId)
+				.userId(userId)
+				.build();
+
+			kafkaOutboxRepository.save(outbox);
+			log.info("[Outbox] 저장 완료 - sagaId: {}", sagaId);
+
+		} catch (JsonProcessingException e) {
+			log.error("[Outbox] 직렬화 실패 - sagaId: {}", sagaId);
+			throw new IllegalArgumentException("메시지 직렬화 오류", e);
+		} catch (Exception e) {
+			log.error("[Outbox] 시스템 오류 - sagaId: {}", sagaId, e);
+			throw new RuntimeException("아웃박스 처리 중 예외 발생", e);
+		}
 	}
 }

--- a/product/src/main/java/com/high/product/infrastructure/persistence/JpaKafkaOutboxRepository.java
+++ b/product/src/main/java/com/high/product/infrastructure/persistence/JpaKafkaOutboxRepository.java
@@ -1,0 +1,15 @@
+package com.high.product.infrastructure.persistence;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.high.product.domain.model.KafkaOutbox;
+
+@Repository
+public interface JpaKafkaOutboxRepository extends JpaRepository<KafkaOutbox, UUID> {
+
+	List<KafkaOutbox> findTop100ByStatusOrderByCreatedAtAsc(String status);
+}

--- a/product/src/main/java/com/high/product/infrastructure/persistence/KafkaOutboxAdapter.java
+++ b/product/src/main/java/com/high/product/infrastructure/persistence/KafkaOutboxAdapter.java
@@ -1,0 +1,35 @@
+package com.high.product.infrastructure.persistence;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.high.product.domain.model.KafkaOutbox;
+import com.high.product.domain.repository.KafkaOutboxRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaOutboxAdapter implements KafkaOutboxRepository {
+
+	private final JpaKafkaOutboxRepository jpaKafkaOutboxRepository;
+
+	@Override
+	public List<KafkaOutbox> findTop100ByStatusOrderByCreatedAtAsc(String status) {
+		return jpaKafkaOutboxRepository.findTop100ByStatusOrderByCreatedAtAsc(status);
+	}
+
+	@Override
+	public KafkaOutbox save(KafkaOutbox outbox) {
+		return jpaKafkaOutboxRepository.save(outbox);
+	}
+
+	@Override
+	public void markAsSent(KafkaOutbox outbox) {
+		// 1. 엔티티 내부의 상태 변경 메서드 호출 (비즈니스 로직)
+		outbox.markSent();
+		// 2. 변경된 엔티티를 DB에 저장
+		jpaKafkaOutboxRepository.save(outbox);
+	}
+}

--- a/product/src/main/java/com/high/product/infrastructure/redis/RedisCacheConfig.java
+++ b/product/src/main/java/com/high/product/infrastructure/redis/RedisCacheConfig.java
@@ -12,12 +12,30 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 @Configuration
 @EnableCaching
 public class RedisCacheConfig {
 
 	@Bean
 	public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+
+		// LocalDateTime 등 Java 8 날짜/시간 타입을 지원하기 위한 ObjectMapper 설정
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule()); // 날짜/시간 모듈 등록
+
+		// Redis에 저장된 JSON을 다시 객체로 바꿀 때 클래스 정보를 포함하도록 설정 (역직렬화 시 에러 방지)
+		PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+			.allowIfBaseType(Object.class)
+			.build();
+		objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
+
+		// 커스텀 ObjectMapper를 적용한 Serializer 생성
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 
 		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
 			.entryTtl(Duration.ofSeconds(5))
@@ -26,9 +44,7 @@ public class RedisCacheConfig {
 				RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
 			)
 			.serializeValuesWith(
-				RedisSerializationContext.SerializationPair.fromSerializer(
-					new GenericJackson2JsonRedisSerializer()
-				)
+				RedisSerializationContext.SerializationPair.fromSerializer(serializer)
 			);
 
 		return RedisCacheManager.builder(connectionFactory)
@@ -36,4 +52,3 @@ public class RedisCacheConfig {
 			.build();
 	}
 }
-

--- a/product/src/main/java/com/high/product/infrastructure/redis/SagaIdDeduplication.java
+++ b/product/src/main/java/com/high/product/infrastructure/redis/SagaIdDeduplication.java
@@ -17,20 +17,30 @@ public class SagaIdDeduplication implements SagaDeduplicationPort {
 	private final RedissonClient redissonClient;
 
 	// 이미 존재하는지 체크
+	@Override
 	public boolean exists(String key) {
 		return Boolean.TRUE.equals(redissonClient.getBucket(key).get());
 	}
 
 	// 최초 처리 시도
+	@Override
 	public boolean tryProcess(String key, long ttlSeconds) {
 		RBucket<Boolean> bucket = redissonClient.getBucket(key);
 		Boolean exists = bucket.get();
-		if (exists != null && exists) return false;
+		if (exists != null && exists)
+			return false;
 		bucket.set(true, ttlSeconds, TimeUnit.SECONDS);
 		return true;
 	}
 
+	// 최종 실패 상태 등을 강제로 저장할 때 사용
+	@Override
+	public void save(String key, long ttlSeconds) {
+		redissonClient.getBucket(key).set(true, ttlSeconds, TimeUnit.SECONDS);
+	}
+
 	// processing key 삭제 (재처리 가능)
+	@Override
 	public void remove(String key) {
 		redissonClient.getBucket(key).delete();
 	}


### PR DESCRIPTION
## Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
- closed #154 

## 📝 Description
- Retry와 DLQ를 연동해서 구현
- 컨슈머: 이벤트 실패-> 특정 횟수 재시도 -> 최종 실패 시 DLQ로 이동 및 관리
- 프로듀서: 아웃박스 패턴을 적용하여 구현

## 🌐 Test Result
<details>
  <summary>테스트 결과</summary>
  
<img width="1714" height="221" alt="재고_분산락_성공" src="https://github.com/user-attachments/assets/3bc856e9-0573-479c-b054-61d6b1b281a1" />
<img width="1631" height="328" alt="재고_분산락_성공2" src="https://github.com/user-attachments/assets/cdb82a48-dbe9-4b42-a417-7f669df29f2e" />
<img width="1296" height="91" alt="재고_분산락_성공3" src="https://github.com/user-attachments/assets/2aa3ff00-af37-4e41-a13a-e089375ab4c1" />
<img width="1799" height="466" alt="프로듀서_아웃박스" src="https://github.com/user-attachments/assets/6686ab67-7c47-43d3-9821-164fc45e3e7e" />
<img width="1604" height="516" alt="프로듀서_아웃박스_스케쥴러" src="https://github.com/user-attachments/assets/0b104800-dcb3-42ad-a418-73812ddcdd04" />
<img width="894" height="460" alt="프로듀서_아웃박스2" src="https://github.com/user-attachments/assets/5c9fbfd7-3488-475b-b52c-98b0fb69de6f" />
</details>

- 이벤트 발행 성공 시에는 KafkaOutboxPublisher(아웃박스 스케쥴러)에 의해 5초 간격으로 PENDING -> SENT로 status 필드의 상태를 변경합니다
```java
@Scheduled(fixedDelay = 5000)
```
이벤트 발행 실패 시에는 먼저 StockDeductionKafkaConsumer, StockRestoreKafkaConsumer에서 3회 재시도 후 DLQ로 이동하고 이벤트는 최종 실패 처리(FAILED)하게 됩니다
```java	
    @RetryableTopic
	@KafkaListener(
		// 재고 차감 토픽과 재시도용 토픽을 모두 구독하도록 추가
		topics = "stock-deduction-request",
		groupId = "product-service-group"
	)
	public void consume(String message) throws Exception {
```
```
	// 재시도 최종 실패 시, 해당 이벤트 DLQ로 이동
	@DltHandler
	@Transactional
	public void handleDlt(String message,
		Exception e,
		@Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
		@Header(KafkaHeaders.OFFSET) long offset,
		@Header(KafkaHeaders.GROUP_ID) String consumerGroup) {
```


## 🔎 To Reviewer
- 수정하거나 잘못된 부분이 없는지
