### PR TITLE
docs: User Service - Swagger 문서화 및 API 설명 추가

### DIFF
--- a/gateway/src/main/java/com/high/gateway/config/CircuitBreakerEventConfig.java
+++ b/gateway/src/main/java/com/high/gateway/config/CircuitBreakerEventConfig.java
@@ -14,7 +14,8 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class CircuitBreakerEventConfig {
+public class
+CircuitBreakerEventConfig {
 
     private final CircuitBreakerRegistry circuitBreakerRegistry;
 

--- a/user/src/main/java/com/high/user/application/dto/request/ChangePasswordRequest.java
+++ b/user/src/main/java/com/high/user/application/dto/request/ChangePasswordRequest.java
@@ -1,12 +1,16 @@
 package com.high.user.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
+@Schema(description = "비밀번호 변경 요청")
 public record ChangePasswordRequest(
+    @Schema(description = "현재 비밀번호", example = "OldPass123!", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "현재 비밀번호를 입력해주세요")
     String currentPassword,
 
+    @Schema(description = "새 비밀번호 (8자 이상, 영문+숫자+특수문자)", example = "NewPass456!", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "새 비밀번호를 입력해주세요")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
              message = "비밀번호는 8자 이상, 영문, 숫자, 특수문자를 포함해야 합니다")

--- a/user/src/main/java/com/high/user/application/dto/request/LoginRequest.java
+++ b/user/src/main/java/com/high/user/application/dto/request/LoginRequest.java
@@ -1,12 +1,16 @@
 package com.high.user.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "로그인 요청")
 public record LoginRequest(
 
+    @Schema(description = "사용자 이메일", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "이메일은 필수입니다")
     String email,
 
+    @Schema(description = "비밀번호", example = "Pass123!", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "비밀번호는 필수입니다")
     String password
 ) {

--- a/user/src/main/java/com/high/user/application/dto/request/SignupRequest.java
+++ b/user/src/main/java/com/high/user/application/dto/request/SignupRequest.java
@@ -1,16 +1,20 @@
 package com.high.user.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "회원가입 요청")
 public record SignupRequest(
 
+    @Schema(description = "이메일 (로그인 ID)", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "이메일은 필수입니다")
     @Email(message = "올바른 이메일 형식이 아닙니다")
     String email,
 
+    @Schema(description = "비밀번호 (8자 이상, 영문+숫자+특수문자)", example = "Pass123!", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "비밀번호는 필수입니다")
     @Pattern(
         regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
@@ -18,17 +22,21 @@ public record SignupRequest(
     )
     String password,
 
+    @Schema(description = "사용자 이름", example = "홍길동", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "이름은 필수입니다")
     String name,
 
+    @Schema(description = "전화번호 (형식: 010-1234-5678)", example = "010-1234-5678")
     @Pattern(
           regexp = "^(010)(-?\\d{4})(-?\\d{4})$",
           message = "전화번호 형식이 올바르지 않습니다 (예: 010-1234-5678)"
     ) String phoneNumber,
 
+    @Schema(description = "배송 주소 (최대 255자)", example = "서울시 강남구 테헤란로 123")
     @Size(max = 255, message = "배송 주소는 255자 이하여야 합니다")
     String deliveryAddress,
 
+    @Schema(description = "상세 주소 (최대 255자)", example = "101동 101호")
     @Size(max = 255, message = "상세 주소는 255자 이하여야 합니다")
     String detailAddress
 ) {

--- a/user/src/main/java/com/high/user/application/dto/request/UpdateUserRequest.java
+++ b/user/src/main/java/com/high/user/application/dto/request/UpdateUserRequest.java
@@ -1,19 +1,25 @@
 package com.high.user.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "회원정보 수정 요청 (변경할 필드만 전송)")
 public record UpdateUserRequest(
+    @Schema(description = "사용자 이름 (최대 50자)", example = "홍길동")
     @Size(max = 50, message = "이름은 50자 이하여야 합니다")
     String name,
 
+    @Schema(description = "전화번호 (형식: 010-1234-5678)", example = "010-9876-5432")
     @Pattern(regexp = "^(010)(-?\\d{4})(-?\\d{4})$",
              message = "전화번호 형식이 올바르지 않습니다 (예: 010-1234-5678)")
     String phoneNumber,
 
+    @Schema(description = "배송 주소 (최대 255자)", example = "서울시 강남구 역삼로 456")
     @Size(max = 255, message = "배송 주소는 255자 이하여야 합니다")
     String deliveryAddress,
 
+    @Schema(description = "상세 주소 (최대 255자)", example = "202동 202호")
     @Size(max = 255, message = "상세 주소는 255자 이하여야 합니다")
     String detailAddress
 ) {

--- a/user/src/main/java/com/high/user/application/dto/response/TokenResponse.java
+++ b/user/src/main/java/com/high/user/application/dto/response/TokenResponse.java
@@ -1,8 +1,16 @@
 package com.high.user.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "JWT 토큰 응답")
 public record TokenResponse(
+    @Schema(description = "Access Token (Bearer 토큰)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     String accessToken,
+
+    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     String refreshToken,
+
+    @Schema(description = "Access Token 만료 시간 (초)", example = "3600")
     Long expiresIn
 ) {
     public static TokenResponse of(String accessToken, String refreshToken, Long expiresIn) {

--- a/user/src/main/java/com/high/user/application/dto/response/UserResponse.java
+++ b/user/src/main/java/com/high/user/application/dto/response/UserResponse.java
@@ -2,20 +2,41 @@ package com.high.user.application.dto.response;
 
 import com.high.user.domain.entity.User;
 import com.high.user.domain.vo.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Schema(description = "사용자 정보 응답")
 public record UserResponse(
+        @Schema(description = "사용자 고유 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID userId,
+
+        @Schema(description = "이메일", example = "user@example.com")
         String email,
+
+        @Schema(description = "사용자 이름", example = "홍길동")
         String name,
+
+        @Schema(description = "권한 (USER, SELLER, MASTER)", example = "USER")
         UserRole role,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
         String phoneNumber,
+
+        @Schema(description = "배송 주소", example = "서울시 강남구 테헤란로 123")
         String deliveryAddress,
+
+        @Schema(description = "상세 주소", example = "101동 101호")
         String detailAddress,
+
+        @Schema(description = "활성화 상태", example = "true")
         Boolean isActive,
+
+        @Schema(description = "마지막 로그인 시간", example = "2025-01-15T10:30:00")
         LocalDateTime lastLoginAt,
+
+        @Schema(description = "가입일시", example = "2025-01-01T09:00:00")
         LocalDateTime createdAt
 ) {
     public static UserResponse from(User user) {

--- a/user/src/main/java/com/high/user/infrastructure/config/SwaggerConfig.java
+++ b/user/src/main/java/com/high/user/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.high.user.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("High-Tension User Service API")
+                .version("v1.0.0")
+                .description("User Service API 문서입니다. JWT 인증이 필요한 API는 Authorize 버튼을 클릭하여 토큰을 입력하세요.")
+                .contact(new Contact()
+                    .name("박근용")
+                    .email("gypark@example.com")))
+            .servers(List.of(
+                new Server().url("http://localhost:8100").description("로컬 개발 환경"),
+                new Server().url("http://localhost:8000/api/v1/users").description("Gateway 경유")
+            ))
+            .components(new Components()
+                .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+                    .in(SecurityScheme.In.HEADER)
+                    .name("Authorization")));
+    }
+}

--- a/user/src/main/java/com/high/user/presentation/AdminController.java
+++ b/user/src/main/java/com/high/user/presentation/AdminController.java
@@ -3,7 +3,14 @@ package com.high.user.presentation;
 import com.high.user.application.dto.request.UpdateRoleRequest;
 import com.high.user.application.dto.response.UserSearchResponse;
 import com.high.user.application.service.AdminService;
-import com.library.module.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Tag(name = "Admin", description = "관리자 전용 사용자 관리 API (MASTER 권한 필요)")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/master/users")
@@ -23,29 +31,42 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    /**
-     * 이메일로 사용자 검색
-     * GET /api/v1/master/users/search?email={email}&page=0&size=10
-     */
+    @Operation(summary = "사용자 검색", description = "이메일로 사용자를 검색합니다 (부분 일치, 페이징).",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "검색 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "403", description = "권한 없음 (MASTER 권한 필요)")
+    })
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse<Page<UserSearchResponse>>> searchUsers(
+    public ResponseEntity<com.library.module.response.ApiResponse<Page<UserSearchResponse>>> searchUsers(
+            @Parameter(description = "검색할 이메일 (부분 일치)", required = true, example = "user@example.com")
             @RequestParam String email,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10")
             @RequestParam(defaultValue = "10") int size) {
 
         log.info("[ADMIN] Search users request: email={}", email);
 
         Page<UserSearchResponse> response = adminService.searchUsersByEmail(email, page, size);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 
-    /**
-     * 사용자 권한 변경
-     * PATCH /api/v1/master/users/{userId}/role
-     */
+    @Operation(summary = "권한 변경", description = "사용자의 권한을 변경합니다 (USER, SELLER, MASTER).",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "권한 변경 성공",
+            content = @Content(schema = @Schema(implementation = UserSearchResponse.class))),
+        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "403", description = "권한 없음 (MASTER 권한 필요)"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @PatchMapping("/{userId}/role")
-    public ResponseEntity<ApiResponse<UserSearchResponse>> updateUserRole(
+    public ResponseEntity<com.library.module.response.ApiResponse<UserSearchResponse>> updateUserRole(
+            @Parameter(description = "사용자 ID", required = true)
             @PathVariable UUID userId,
             @Valid @RequestBody UpdateRoleRequest request) {
 
@@ -53,6 +74,6 @@ public class AdminController {
 
         UserSearchResponse response = adminService.updateUserRole(userId, request);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 }

--- a/user/src/main/java/com/high/user/presentation/PasskeyController.java
+++ b/user/src/main/java/com/high/user/presentation/PasskeyController.java
@@ -7,8 +7,15 @@ import com.high.user.application.dto.request.PasskeyRegistrationStartRequest;
 import com.high.user.application.dto.request.PasskeyUpdateRequest;
 import com.high.user.application.dto.response.*;
 import com.high.user.application.service.PasskeyService;
-import com.library.module.response.ApiResponse;
 import com.library.security.util.SecurityContextUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Passkey", description = "WebAuthn (FIDO2) 패스키 인증 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/passkeys")
@@ -28,13 +36,15 @@ public class PasskeyController {
 
     private final PasskeyService passkeyService;
 
-    /**
-     * 패스키 등록 시작
-     * POST /api/v1/passkeys/register/start
-     */
+    @Operation(summary = "패스키 등록 시작", description = "WebAuthn 패스키 등록 프로세스를 시작하고 Challenge를 생성합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "등록 시작 성공 (Challenge 반환)"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PostMapping("/register/start")
-    public ResponseEntity<ApiResponse<PasskeyRegistrationStartResponse>> startRegistration(
+    public ResponseEntity<com.library.module.response.ApiResponse<PasskeyRegistrationStartResponse>> startRegistration(
             @Valid @RequestBody(required = false) PasskeyRegistrationStartRequest request) {
 
         UUID userId = SecurityContextUtil.getCurrentUserId();
@@ -43,16 +53,19 @@ public class PasskeyController {
         PasskeyRegistrationStartResponse response = passkeyService.startRegistration(
             userId, request != null ? request : new PasskeyRegistrationStartRequest(null));
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 
-    /**
-     * 패스키 등록 완료
-     * POST /api/v1/passkeys/register/finish
-     */
+    @Operation(summary = "패스키 등록 완료", description = "WebAuthn 패스키 등록을 완료하고 Credential을 저장합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "패스키 등록 완료"),
+        @ApiResponse(responseCode = "400", description = "유효하지 않은 인증 응답"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PostMapping("/register/finish")
-    public ResponseEntity<ApiResponse<PasskeyRegistrationFinishResponse>> finishRegistration(
+    public ResponseEntity<com.library.module.response.ApiResponse<PasskeyRegistrationFinishResponse>> finishRegistration(
             @Valid @RequestBody PasskeyRegistrationFinishRequest request) {
 
         UUID userId = SecurityContextUtil.getCurrentUserId();
@@ -60,15 +73,15 @@ public class PasskeyController {
 
         PasskeyRegistrationFinishResponse response = passkeyService.finishRegistration(userId, request);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(com.library.module.response.ApiResponse.success(response));
     }
 
-    /**
-     * 패스키 인증 시작 (로그인)
-     * POST /api/v1/passkeys/authenticate/start
-     */
+    @Operation(summary = "패스키 인증 시작", description = "WebAuthn 패스키 로그인 프로세스를 시작하고 Challenge를 생성합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "인증 시작 성공 (Challenge 반환)")
+    })
     @PostMapping("/authenticate/start")
-    public ResponseEntity<ApiResponse<PasskeyAuthenticationStartResponse>> startAuthentication(
+    public ResponseEntity<com.library.module.response.ApiResponse<PasskeyAuthenticationStartResponse>> startAuthentication(
             @Valid @RequestBody(required = false) PasskeyAuthenticationStartRequest request) {
 
         log.info("[POST] Passkey authentication start");
@@ -76,47 +89,57 @@ public class PasskeyController {
         PasskeyAuthenticationStartResponse response = passkeyService.startAuthentication(
             request != null ? request : new PasskeyAuthenticationStartRequest(null));
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 
-    /**
-     * 패스키 인증 완료 (로그인 - JWT 발급)
-     * POST /api/v1/passkeys/authenticate/finish
-     */
+    @Operation(summary = "패스키 인증 완료", description = "WebAuthn 패스키 인증을 완료하고 JWT 토큰을 발급합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "인증 성공 (JWT 토큰 반환)",
+            content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+        @ApiResponse(responseCode = "400", description = "유효하지 않은 인증 응답"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping("/authenticate/finish")
-    public ResponseEntity<ApiResponse<TokenResponse>> finishAuthentication(
+    public ResponseEntity<com.library.module.response.ApiResponse<TokenResponse>> finishAuthentication(
             @Valid @RequestBody PasskeyAuthenticationFinishRequest request) {
 
         log.info("[POST] Passkey authentication finish");
 
         TokenResponse response = passkeyService.finishAuthentication(request);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 
-    /**
-     * 내 패스키 목록 조회
-     * GET /api/v1/passkeys
-     */
+    @Operation(summary = "내 패스키 목록 조회", description = "현재 로그인한 사용자가 등록한 모든 패스키 목록을 조회합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<PasskeyListResponse>>> getPasskeys() {
+    public ResponseEntity<com.library.module.response.ApiResponse<List<PasskeyListResponse>>> getPasskeys() {
 
         UUID userId = SecurityContextUtil.getCurrentUserId();
         log.info("[GET] Get passkeys: userId={}", userId);
 
         List<PasskeyListResponse> response = passkeyService.getPasskeys(userId);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 
-    /**
-     * 패스키 이름 수정
-     * PATCH /api/v1/passkeys/{passkeyId}
-     */
+    @Operation(summary = "패스키 이름 수정", description = "등록된 패스키의 이름을 변경합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "수정 성공"),
+        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "패스키를 찾을 수 없음")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PatchMapping("/{passkeyId}")
-    public ResponseEntity<ApiResponse<PasskeyListResponse>> updateCredentialName(
+    public ResponseEntity<com.library.module.response.ApiResponse<PasskeyListResponse>> updateCredentialName(
+            @Parameter(description = "패스키 ID", required = true)
             @PathVariable UUID passkeyId,
             @Valid @RequestBody PasskeyUpdateRequest request) {
 
@@ -126,22 +149,27 @@ public class PasskeyController {
 
         PasskeyListResponse response = passkeyService.updateCredentialName(userId, passkeyId, request);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 
-    /**
-     * 패스키 삭제
-     * DELETE /api/v1/passkeys/{passkeyId}
-     */
+    @Operation(summary = "패스키 삭제", description = "등록된 패스키를 삭제합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "삭제 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "패스키를 찾을 수 없음")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @DeleteMapping("/{passkeyId}")
-    public ResponseEntity<ApiResponse<Void>> deletePasskey(@PathVariable UUID passkeyId) {
+    public ResponseEntity<com.library.module.response.ApiResponse<Void>> deletePasskey(
+            @Parameter(description = "패스키 ID", required = true)
+            @PathVariable UUID passkeyId) {
 
         UUID userId = SecurityContextUtil.getCurrentUserId();
         log.info("[DELETE] Delete passkey: userId={}, passkeyId={}", userId, passkeyId);
 
         passkeyService.deletePasskey(userId, passkeyId);
 
-        return ResponseEntity.ok(ApiResponse.success("패스키가 삭제되었습니다."));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success("패스키가 삭제되었습니다."));
     }
 }

--- a/user/src/main/java/com/high/user/presentation/UserController.java
+++ b/user/src/main/java/com/high/user/presentation/UserController.java
@@ -7,8 +7,14 @@ import com.high.user.application.dto.response.UserResponse;
 import com.high.user.application.service.UserAuthService;
 import com.high.user.application.service.UserCouponService;
 import com.high.user.application.service.UserService;
-import com.library.module.response.ApiResponse;
 import com.library.security.util.SecurityContextUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "User", description = "사용자 인증 및 정보 관리 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/users")
@@ -30,8 +37,15 @@ public class UserController {
     private final UserService userService;
     private final UserCouponService userCouponService;
 
+    @Operation(summary = "회원가입", description = "신규 사용자를 등록합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "회원가입 성공",
+            content = @Content(schema = @Schema(implementation = UserResponse.class))),
+        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일")
+    })
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<UserResponse>> signup(
+    public ResponseEntity<com.library.module.response.ApiResponse<UserResponse>> signup(
             @Valid @RequestBody SignupRequest request) {
         log.info("Signup request received: email={}", request.email());
 
@@ -39,33 +53,53 @@ public class UserController {
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(ApiResponse.success(response));
+                .body(com.library.module.response.ApiResponse.success(response));
     }
 
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "로그인 성공",
+            content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @ApiResponse(responseCode = "401", description = "인증 실패 (이메일 또는 비밀번호 불일치)")
+    })
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<TokenResponse>> login(
+    public ResponseEntity<com.library.module.response.ApiResponse<TokenResponse>> login(
             @Valid @RequestBody LoginRequest request) {
         log.info("Login request received: email={}", request.email());
 
         TokenResponse response = userAuthService.login(request);
 
         return ResponseEntity
-                .ok(ApiResponse.success(response));
+                .ok(com.library.module.response.ApiResponse.success(response));
     }
 
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 새로운 Access Token을 발급받습니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+            content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token")
+    })
     @PostMapping("/reissue")
-    public ResponseEntity<ApiResponse<TokenResponse>> reissueToken(
+    public ResponseEntity<com.library.module.response.ApiResponse<TokenResponse>> reissueToken(
             @Valid @RequestBody TokenReissueRequest request) {
         log.info("Token reissue request received");
 
         TokenResponse response = userAuthService.reissueToken(request);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 
+    @Operation(summary = "로그아웃", description = "현재 로그인한 사용자를 로그아웃하고 토큰을 무효화합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패 (유효하지 않은 토큰)")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(
+    public ResponseEntity<com.library.module.response.ApiResponse<Void>> logout(
             @RequestHeader("Authorization") String bearerToken) {
         UUID userId = SecurityContextUtil.getCurrentUserId();
         String accessToken = bearerToken.substring(7);
@@ -74,24 +108,40 @@ public class UserController {
 
         userAuthService.logout(accessToken, userId.toString());
 
-        return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다."));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success("로그아웃 되었습니다."));
     }
 
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = UserResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo() {
+    public ResponseEntity<com.library.module.response.ApiResponse<UserResponse>> getMyInfo() {
         UUID userId = SecurityContextUtil.getCurrentUserId();
 
         log.info("Get my info request received: userId={}", userId);
 
         UserResponse response = userService.getUserById(userId.toString());
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 
+    @Operation(summary = "회원정보 수정", description = "이름, 전화번호, 주소를 수정합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "수정 성공",
+            content = @Content(schema = @Schema(implementation = UserResponse.class))),
+        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PutMapping("/me")
-    public ResponseEntity<ApiResponse<UserResponse>> updateUserInfo(
+    public ResponseEntity<com.library.module.response.ApiResponse<UserResponse>> updateUserInfo(
             @Valid @RequestBody UpdateUserRequest request) {
         UUID userId = SecurityContextUtil.getCurrentUserId();
 
@@ -99,12 +149,19 @@ public class UserController {
 
         UserResponse response = userService.updateUserInfo(userId, request);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 
+    @Operation(summary = "비밀번호 변경", description = "현재 비밀번호를 확인하고 새 비밀번호로 변경합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음 또는 현재 비밀번호 불일치"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PatchMapping("/me/password")
-    public ResponseEntity<ApiResponse<Void>> changePassword(
+    public ResponseEntity<com.library.module.response.ApiResponse<Void>> changePassword(
             @Valid @RequestBody ChangePasswordRequest request) {
         UUID userId = SecurityContextUtil.getCurrentUserId();
 
@@ -112,9 +169,16 @@ public class UserController {
 
         userService.changePassword(userId, request);
 
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(null));
     }
 
+    @Operation(summary = "회원 탈퇴", description = "비밀번호를 확인하고 회원을 탈퇴합니다 (Soft Delete).",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공"),
+        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음 또는 비밀번호 불일치"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteUser(
@@ -128,19 +192,21 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * 내 보유 쿠폰 목록 조회
-     * GET /api/v1/users/me/coupons
-     */
+    @Operation(summary = "내 쿠폰 조회", description = "현재 로그인한 사용자가 보유한 쿠폰 목록을 조회합니다.",
+        security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @GetMapping("/me/coupons")
-    public ResponseEntity<ApiResponse<List<CouponResponse>>> getMyCoupons() {
+    public ResponseEntity<com.library.module.response.ApiResponse<List<CouponResponse>>> getMyCoupons() {
         UUID userId = SecurityContextUtil.getCurrentUserId();
 
         log.info("Get my coupons request received: userId={}", userId);
 
         List<CouponResponse> response = userCouponService.getUserCoupons(userId);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
     }
 }

--- a/user/src/main/resources/application.yaml
+++ b/user/src/main/resources/application.yaml
@@ -33,3 +33,18 @@ webauthn:
     origins: ${WEBAUTHN_ORIGINS:http://localhost:3000,http://localhost:8000}
   challenge:
     ttl-minutes: 5
+
+# SpringDoc OpenAPI Configuration
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true
+    tags-sorter: alpha
+    operations-sorter: method
+    display-request-duration: true
+    try-it-out-enabled: true
+    filter: true
+    disable-swagger-default-url: true


### PR DESCRIPTION
## Issue Number
- closed #166

## 📝 Description

SpringDoc OpenAPI 3.0을 활용하여 User Service의 20개 엔드포인트에 대한 인터랙티브 API 문서를 생성했습니다.

### 주요 변경사항

#### 1. Swagger 설정
- **SwaggerConfig.java**: OpenAPI Bean 정의
  - JWT Bearer 인증 스키마 설정 (`bearer-jwt`)
  - API 메타 정보 (title, version, description, contact)
  - 서버 URL 설정 (localhost:8100, Gateway 경유)
- **application.yaml**: springdoc 설정 추가
  - Swagger UI 경로: `/swagger-ui.html`
  - OpenAPI JSON 경로: `/v3/api-docs`
  - UI 옵션: 태그/작업 정렬, Try It Out 활성화

#### 2. Controller 문서화 (20개 엔드포인트)
- **UserController** (9개)
  - `@Tag`: "User" - 사용자 인증 및 정보 관리 API
  - `@Operation`, `@ApiResponses`, `@SecurityRequirement` 추가
  - 회원가입, 로그인, 로그아웃, 토큰 재발급, 내 정보 조회/수정, 비밀번호 변경, 회원 탈퇴, 내 쿠폰 조회

- **AdminController** (2개)
  - `@Tag`: "Admin" - 관리자 전용 사용자 관리 API
  - `@Parameter` 어노테이션으로 쿼리 파라미터 설명
  - 사용자 검색(페이징), 권한 변경

- **PasskeyController** (7개)
  - `@Tag`: "Passkey" - WebAuthn (FIDO2) 패스키 인증 API
  - 패스키 등록/인증 시작/완료, 목록 조회, 이름 수정, 삭제

#### 3. DTO 스키마 문서화
- **Request DTO** (4개): `@Schema` 어노테이션 추가
  - SignupRequest, LoginRequest, UpdateUserRequest, ChangePasswordRequest
  - 각 필드에 description, example, requiredMode 설정

- **Response DTO** (2개): `@Schema` 어노테이션 추가
  - UserResponse (10개 필드), TokenResponse (3개 필드)
  - 클래스 및 필드 레벨 설명

## 🌐 Test Result

<img width="1439" height="874" alt="image" src="https://github.com/user-attachments/assets/2682c8f7-b894-4f7c-ab9c-bf302490d05f" />

## 🔎 To Reviewer

1. **JWT 인증 통합**: `@SecurityRequirement(name = "bearer-jwt")`로 인증 필요 API 명시가 적절한지 검토 부탁드립니다.
2. **DTO 예시 값**: 실제 사용 가능한 값으로 설정했는지 확인 부탁드립니다.
3. **응답 코드**: 각 엔드포인트의 응답 코드(200, 201, 400, 401, 404, 409 등)가 실제 구현과 일치하는지 확인 부탁드립니다.