### PR TITLE
feat: Gateway & User Service - Warmup Endpoint 구현

### DIFF
--- a/gateway/src/main/java/com/high/gateway/controller/WarmupController.java
+++ b/gateway/src/main/java/com/high/gateway/controller/WarmupController.java
@@ -1,0 +1,76 @@
+package com.high.gateway.controller;
+
+import com.high.gateway.service.TokenBucketService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Gateway Warmup Controller
+ *
+ * 서비스 재시작 후 Cold Start 문제를 해결하기 위한 Warmup 엔드포인트
+ * Redis 연결 및 TokenBucket 서비스를 사전 초기화합니다.
+ *
+ * Kubernetes Readiness Probe 및 Docker healthcheck로 사용 가능합니다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class WarmupController {
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+    private final TokenBucketService tokenBucketService;
+
+    @GetMapping("/warmup")
+    public Mono<ResponseEntity<Map<String, Object>>> warmup() {
+        log.info("Starting Gateway warmup...");
+
+        return Mono.zip(
+            warmupRedis(),
+            warmupTokenBucket()
+        ).map(tuple -> {
+            Map<String, Object> result = new HashMap<>();
+            result.put("status", "success");
+            result.put("components", Map.of(
+                "redis", tuple.getT1(),
+                "tokenBucket", tuple.getT2()
+            ));
+            result.put("timestamp", System.currentTimeMillis());
+
+            log.info("Gateway warmup completed successfully");
+            return ResponseEntity.ok(result);
+        }).onErrorResume(error -> {
+            log.error("Gateway warmup failed", error);
+
+            Map<String, Object> result = new HashMap<>();
+            result.put("status", "failure");
+            result.put("error", error.getMessage());
+            result.put("timestamp", System.currentTimeMillis());
+
+            return Mono.just(ResponseEntity.status(503).body(result));
+        });
+    }
+
+    private Mono<String> warmupRedis() {
+        return reactiveRedisTemplate.opsForValue()
+            .get("warmup:gateway:test")
+            .doOnSuccess(v -> log.info("Redis warmup successful"))
+            .defaultIfEmpty("ok")
+            .map(v -> "initialized");
+    }
+
+    private Mono<String> warmupTokenBucket() {
+        return tokenBucketService.tryConsume("warmup:gateway:test", 1)
+            .doOnSuccess(success -> log.info("TokenBucket warmup successful: {}", success))
+            .map(success -> "initialized");
+    }
+}

--- a/gateway/src/main/java/com/high/gateway/runner/WarmupRunner.java
+++ b/gateway/src/main/java/com/high/gateway/runner/WarmupRunner.java
@@ -1,0 +1,65 @@
+package com.high.gateway.runner;
+
+import com.high.gateway.service.TokenBucketService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Gateway Warmup Runner
+ *
+ * 애플리케이션 시작 시 주요 컴포넌트를 자동으로 초기화합니다.
+ * Cold Start 문제를 방지하여 첫 요청 지연을 최소화합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WarmupRunner implements ApplicationRunner {
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+    private final TokenBucketService tokenBucketService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("=== Gateway Warmup 시작 ===");
+        long startTime = System.currentTimeMillis();
+
+        try {
+            // Redis 연결 초기화
+            warmupRedis();
+
+            // TokenBucket 서비스 초기화
+            warmupTokenBucket();
+
+            long elapsed = System.currentTimeMillis() - startTime;
+            log.info("=== Gateway Warmup 완료 ({}ms) ===", elapsed);
+
+        } catch (Exception e) {
+            log.error("Gateway Warmup 실패", e);
+        }
+    }
+
+    private void warmupRedis() {
+        try {
+            reactiveRedisTemplate.opsForValue()
+                .get("warmup:gateway:init")
+                .block();
+            log.info("Redis 연결 초기화 완료");
+        } catch (Exception e) {
+            log.warn("Redis 연결 초기화 실패: {}", e.getMessage());
+        }
+    }
+
+    private void warmupTokenBucket() {
+        try {
+            tokenBucketService.tryConsume("warmup:gateway:init", 1)
+                .block();
+            log.info("TokenBucket 서비스 초기화 완료");
+        } catch (Exception e) {
+            log.warn("TokenBucket 서비스 초기화 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/user/src/main/java/com/high/user/application/service/UserService.java
+++ b/user/src/main/java/com/high/user/application/service/UserService.java
@@ -7,6 +7,8 @@ import com.high.user.application.dto.response.UserResponse;
 import com.high.user.domain.entity.User;
 import com.high.user.domain.exception.*;
 import com.high.user.domain.repository.UserRepository;
+import com.high.user.domain.repository.PasskeyRepository;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,6 +25,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final RefreshTokenService refreshTokenService;
+    private final PasskeyRepository passkeyRepository;
 
     /**
      * 사용자 ID로 사용자 정보 조회 (읽기 전용)
@@ -60,13 +63,13 @@ public class UserService {
     public UserResponse updateUserInfo(UUID userId, UpdateUserRequest request) {
         // 최소 1개 필드 검증
         if (request.name() == null && request.phoneNumber() == null &&
-            request.deliveryAddress() == null && request.detailAddress() == null) {
+                request.deliveryAddress() == null && request.detailAddress() == null) {
             throw new IllegalArgumentException("수정할 필드가 없습니다");
         }
 
         // 사용자 조회 (deletedAt이 null인 사용자만)
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
-            .orElseThrow(UserNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         // 계정 활성화 상태 확인
         if (!user.getIsActive()) {
@@ -98,7 +101,7 @@ public class UserService {
     public void changePassword(UUID userId, ChangePasswordRequest request) {
         // 사용자 조회
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
-            .orElseThrow(UserNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         // 현재 비밀번호 검증
         if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
@@ -127,7 +130,7 @@ public class UserService {
     public void deleteUser(UUID userId, DeleteUserRequest request) {
         // 사용자 조회
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
-            .orElseThrow(UserNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         // 이미 탈퇴한 계정인지 확인
         if (user.getDeletedAt() != null) {
@@ -139,8 +142,16 @@ public class UserService {
             throw new InvalidCredentialsException();
         }
 
-        // Soft Delete
-        user.softDelete(userId);
+        // Soft Delete User
+        user.softDelete(userId.toString());
+
+        // Soft Delete Passkeys
+        var passkeys = passkeyRepository.findByUserIdAndDeletedAtIsNull(userId);
+        if (!passkeys.isEmpty()) {
+            passkeys.forEach(pk -> pk.softDelete(userId.toString()));
+            passkeyRepository.saveAll(passkeys);
+            log.info("사용자 패스키 삭제 처리 완료 (Soft Delete) - userId: {}, count: {}", userId, passkeys.size());
+        }
 
         // Refresh Token 삭제
         refreshTokenService.deleteByUserId(userId.toString());

--- a/user/src/main/java/com/high/user/application/service/UserService.java
+++ b/user/src/main/java/com/high/user/application/service/UserService.java
@@ -143,12 +143,12 @@ public class UserService {
         }
 
         // Soft Delete User
-        user.softDelete(userId.toString());
+        user.softDelete(userId);
 
         // Soft Delete Passkeys
         var passkeys = passkeyRepository.findByUserIdAndDeletedAtIsNull(userId);
         if (!passkeys.isEmpty()) {
-            passkeys.forEach(pk -> pk.softDelete(userId.toString()));
+            passkeys.forEach(pk -> pk.softDelete(userId));
             passkeyRepository.saveAll(passkeys);
             log.info("사용자 패스키 삭제 처리 완료 (Soft Delete) - userId: {}, count: {}", userId, passkeys.size());
         }

--- a/user/src/main/java/com/high/user/domain/repository/PasskeyRepository.java
+++ b/user/src/main/java/com/high/user/domain/repository/PasskeyRepository.java
@@ -21,4 +21,10 @@ public interface PasskeyRepository {
     boolean existsByCredentialId(String credentialId);
 
     void deleteById(UUID passkeyId);
+
+    void saveAll(Iterable<Passkey> passkeys);
+
+    List<Passkey> findByDeletedAtBefore(java.time.LocalDateTime dateTime);
+
+    void deleteAll(Iterable<Passkey> passkeys);
 }

--- a/user/src/main/java/com/high/user/infrastructure/persistence/JpaPasskeyRepository.java
+++ b/user/src/main/java/com/high/user/infrastructure/persistence/JpaPasskeyRepository.java
@@ -18,4 +18,6 @@ public interface JpaPasskeyRepository extends JpaRepository<Passkey, UUID> {
     List<Passkey> findByUserIdAndDeletedAtIsNull(UUID userId);
 
     boolean existsByCredentialId(String credentialId);
+
+    List<Passkey> findByDeletedAtBefore(java.time.LocalDateTime deletedAt);
 }

--- a/user/src/main/java/com/high/user/infrastructure/persistence/PasskeyRepositoryAdaptor.java
+++ b/user/src/main/java/com/high/user/infrastructure/persistence/PasskeyRepositoryAdaptor.java
@@ -49,4 +49,19 @@ public class PasskeyRepositoryAdaptor implements PasskeyRepository {
     public void deleteById(UUID passkeyId) {
         jpaPasskeyRepository.deleteById(passkeyId);
     }
+
+    @Override
+    public void saveAll(Iterable<Passkey> passkeys) {
+        jpaPasskeyRepository.saveAll(passkeys);
+    }
+
+    @Override
+    public List<Passkey> findByDeletedAtBefore(java.time.LocalDateTime dateTime) {
+        return jpaPasskeyRepository.findByDeletedAtBefore(dateTime);
+    }
+
+    @Override
+    public void deleteAll(Iterable<Passkey> passkeys) {
+        jpaPasskeyRepository.deleteAll(passkeys);
+    }
 }

--- a/user/src/main/java/com/high/user/infrastructure/runner/WarmupRunner.java
+++ b/user/src/main/java/com/high/user/infrastructure/runner/WarmupRunner.java
@@ -1,0 +1,62 @@
+package com.high.user.infrastructure.runner;
+
+import com.high.user.infrastructure.persistence.JpaUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * User Service Warmup Runner
+ *
+ * 애플리케이션 시작 시 주요 컴포넌트를 자동으로 초기화합니다.
+ * Cold Start 문제를 방지하여 첫 요청 지연을 최소화합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WarmupRunner implements ApplicationRunner {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final JpaUserRepository jpaUserRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("=== User Service Warmup 시작 ===");
+        long startTime = System.currentTimeMillis();
+
+        try {
+            // Redis 연결 초기화
+            warmupRedis();
+
+            // Database/JPA 초기화
+            warmupDatabase();
+
+            long elapsed = System.currentTimeMillis() - startTime;
+            log.info("=== User Service Warmup 완료 ({}ms) ===", elapsed);
+
+        } catch (Exception e) {
+            log.error("User Service Warmup 실패", e);
+        }
+    }
+
+    private void warmupRedis() {
+        try {
+            redisTemplate.opsForValue().get("warmup:user:init");
+            log.info("Redis 연결 초기화 완료");
+        } catch (Exception e) {
+            log.warn("Redis 연결 초기화 실패: {}", e.getMessage());
+        }
+    }
+
+    private void warmupDatabase() {
+        try {
+            long count = jpaUserRepository.count();
+            log.info("Database/JPA 초기화 완료 (user count: {})", count);
+        } catch (Exception e) {
+            log.warn("Database/JPA 초기화 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/user/src/main/java/com/high/user/infrastructure/scheduler/PasskeyCleanupScheduler.java
+++ b/user/src/main/java/com/high/user/infrastructure/scheduler/PasskeyCleanupScheduler.java
@@ -1,0 +1,40 @@
+package com.high.user.infrastructure.scheduler;
+
+import com.high.user.domain.entity.Passkey;
+import com.high.user.domain.repository.PasskeyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PasskeyCleanupScheduler {
+
+    private final PasskeyRepository passkeyRepository;
+
+    /**
+     * Soft Delete 된지 30일이 지난 패스키 영구 삭제
+     * 매일 자정 실행
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void deleteExpiredPasskeys() {
+        log.info("Passkey cleanup scheduler started");
+
+        LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+        List<Passkey> expiredPasskeys = passkeyRepository.findByDeletedAtBefore(threshold);
+
+        if (!expiredPasskeys.isEmpty()) {
+            passkeyRepository.deleteAll(expiredPasskeys);
+            log.info("Deleted {} expired passkeys", expiredPasskeys.size());
+        } else {
+            log.info("No expired passkeys found");
+        }
+    }
+}

--- a/user/src/main/java/com/high/user/presentation/AdminController.java
+++ b/user/src/main/java/com/high/user/presentation/AdminController.java
@@ -3,11 +3,11 @@ package com.high.user.presentation;
 import com.high.user.application.dto.request.UpdateRoleRequest;
 import com.high.user.application.dto.response.UserSearchResponse;
 import com.high.user.application.service.AdminService;
+import com.library.module.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,12 +34,12 @@ public class AdminController {
     @Operation(summary = "사용자 검색", description = "이메일로 사용자를 검색합니다 (부분 일치, 페이징).",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "검색 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 실패"),
-        @ApiResponse(responseCode = "403", description = "권한 없음 (MASTER 권한 필요)")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음 (MASTER 권한 필요)")
     })
     @GetMapping("/search")
-    public ResponseEntity<com.library.module.response.ApiResponse<Page<UserSearchResponse>>> searchUsers(
+    public ResponseEntity<ApiResponse<Page<UserSearchResponse>>> searchUsers(
             @Parameter(description = "검색할 이메일 (부분 일치)", required = true, example = "user@example.com")
             @RequestParam String email,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
@@ -51,21 +51,21 @@ public class AdminController {
 
         Page<UserSearchResponse> response = adminService.searchUsersByEmail(email, page, size);
 
-        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "권한 변경", description = "사용자의 권한을 변경합니다 (USER, SELLER, MASTER).",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "권한 변경 성공",
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "권한 변경 성공",
             content = @Content(schema = @Schema(implementation = UserSearchResponse.class))),
-        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
-        @ApiResponse(responseCode = "401", description = "인증 실패"),
-        @ApiResponse(responseCode = "403", description = "권한 없음 (MASTER 권한 필요)"),
-        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음 (MASTER 권한 필요)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
     @PatchMapping("/{userId}/role")
-    public ResponseEntity<com.library.module.response.ApiResponse<UserSearchResponse>> updateUserRole(
+    public ResponseEntity<ApiResponse<UserSearchResponse>> updateUserRole(
             @Parameter(description = "사용자 ID", required = true)
             @PathVariable UUID userId,
             @Valid @RequestBody UpdateRoleRequest request) {
@@ -74,6 +74,6 @@ public class AdminController {
 
         UserSearchResponse response = adminService.updateUserRole(userId, request);
 
-        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/user/src/main/java/com/high/user/presentation/PasskeyController.java
+++ b/user/src/main/java/com/high/user/presentation/PasskeyController.java
@@ -7,12 +7,12 @@ import com.high.user.application.dto.request.PasskeyRegistrationStartRequest;
 import com.high.user.application.dto.request.PasskeyUpdateRequest;
 import com.high.user.application.dto.response.*;
 import com.high.user.application.service.PasskeyService;
+import com.library.module.response.ApiResponse;
 import com.library.security.util.SecurityContextUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,12 +39,12 @@ public class PasskeyController {
     @Operation(summary = "패스키 등록 시작", description = "WebAuthn 패스키 등록 프로세스를 시작하고 Challenge를 생성합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "등록 시작 성공 (Challenge 반환)"),
-        @ApiResponse(responseCode = "401", description = "인증 실패")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "등록 시작 성공 (Challenge 반환)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PostMapping("/register/start")
-    public ResponseEntity<com.library.module.response.ApiResponse<PasskeyRegistrationStartResponse>> startRegistration(
+    public ResponseEntity<ApiResponse<PasskeyRegistrationStartResponse>> startRegistration(
             @Valid @RequestBody(required = false) PasskeyRegistrationStartRequest request) {
 
         UUID userId = SecurityContextUtil.getCurrentUserId();
@@ -59,13 +59,13 @@ public class PasskeyController {
     @Operation(summary = "패스키 등록 완료", description = "WebAuthn 패스키 등록을 완료하고 Credential을 저장합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "패스키 등록 완료"),
-        @ApiResponse(responseCode = "400", description = "유효하지 않은 인증 응답"),
-        @ApiResponse(responseCode = "401", description = "인증 실패")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "패스키 등록 완료"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 인증 응답"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PostMapping("/register/finish")
-    public ResponseEntity<com.library.module.response.ApiResponse<PasskeyRegistrationFinishResponse>> finishRegistration(
+    public ResponseEntity<ApiResponse<PasskeyRegistrationFinishResponse>> finishRegistration(
             @Valid @RequestBody PasskeyRegistrationFinishRequest request) {
 
         UUID userId = SecurityContextUtil.getCurrentUserId();
@@ -73,15 +73,15 @@ public class PasskeyController {
 
         PasskeyRegistrationFinishResponse response = passkeyService.finishRegistration(userId, request);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(com.library.module.response.ApiResponse.success(response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
     @Operation(summary = "패스키 인증 시작", description = "WebAuthn 패스키 로그인 프로세스를 시작하고 Challenge를 생성합니다.")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "인증 시작 성공 (Challenge 반환)")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 시작 성공 (Challenge 반환)")
     })
     @PostMapping("/authenticate/start")
-    public ResponseEntity<com.library.module.response.ApiResponse<PasskeyAuthenticationStartResponse>> startAuthentication(
+    public ResponseEntity<ApiResponse<PasskeyAuthenticationStartResponse>> startAuthentication(
             @Valid @RequestBody(required = false) PasskeyAuthenticationStartRequest request) {
 
         log.info("[POST] Passkey authentication start");
@@ -94,13 +94,13 @@ public class PasskeyController {
 
     @Operation(summary = "패스키 인증 완료", description = "WebAuthn 패스키 인증을 완료하고 JWT 토큰을 발급합니다.")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "인증 성공 (JWT 토큰 반환)",
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 성공 (JWT 토큰 반환)",
             content = @Content(schema = @Schema(implementation = TokenResponse.class))),
-        @ApiResponse(responseCode = "400", description = "유효하지 않은 인증 응답"),
-        @ApiResponse(responseCode = "401", description = "인증 실패")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 인증 응답"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PostMapping("/authenticate/finish")
-    public ResponseEntity<com.library.module.response.ApiResponse<TokenResponse>> finishAuthentication(
+    public ResponseEntity<ApiResponse<TokenResponse>> finishAuthentication(
             @Valid @RequestBody PasskeyAuthenticationFinishRequest request) {
 
         log.info("[POST] Passkey authentication finish");
@@ -113,12 +113,12 @@ public class PasskeyController {
     @Operation(summary = "내 패스키 목록 조회", description = "현재 로그인한 사용자가 등록한 모든 패스키 목록을 조회합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 실패")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @GetMapping
-    public ResponseEntity<com.library.module.response.ApiResponse<List<PasskeyListResponse>>> getPasskeys() {
+    public ResponseEntity<ApiResponse<List<PasskeyListResponse>>> getPasskeys() {
 
         UUID userId = SecurityContextUtil.getCurrentUserId();
         log.info("[GET] Get passkeys: userId={}", userId);
@@ -131,14 +131,14 @@ public class PasskeyController {
     @Operation(summary = "패스키 이름 수정", description = "등록된 패스키의 이름을 변경합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "수정 성공"),
-        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
-        @ApiResponse(responseCode = "401", description = "인증 실패"),
-        @ApiResponse(responseCode = "404", description = "패스키를 찾을 수 없음")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "패스키를 찾을 수 없음")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PatchMapping("/{passkeyId}")
-    public ResponseEntity<com.library.module.response.ApiResponse<PasskeyListResponse>> updateCredentialName(
+    public ResponseEntity<ApiResponse<PasskeyListResponse>> updateCredentialName(
             @Parameter(description = "패스키 ID", required = true)
             @PathVariable UUID passkeyId,
             @Valid @RequestBody PasskeyUpdateRequest request) {
@@ -155,13 +155,13 @@ public class PasskeyController {
     @Operation(summary = "패스키 삭제", description = "등록된 패스키를 삭제합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "삭제 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 실패"),
-        @ApiResponse(responseCode = "404", description = "패스키를 찾을 수 없음")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "패스키를 찾을 수 없음")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @DeleteMapping("/{passkeyId}")
-    public ResponseEntity<com.library.module.response.ApiResponse<Void>> deletePasskey(
+    public ResponseEntity<ApiResponse<Void>> deletePasskey(
             @Parameter(description = "패스키 ID", required = true)
             @PathVariable UUID passkeyId) {
 

--- a/user/src/main/java/com/high/user/presentation/UserController.java
+++ b/user/src/main/java/com/high/user/presentation/UserController.java
@@ -7,11 +7,11 @@ import com.high.user.application.dto.response.UserResponse;
 import com.high.user.application.service.UserAuthService;
 import com.high.user.application.service.UserCouponService;
 import com.high.user.application.service.UserService;
+import com.library.module.response.ApiResponse;
 import com.library.security.util.SecurityContextUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,13 +39,13 @@ public class UserController {
 
     @Operation(summary = "회원가입", description = "신규 사용자를 등록합니다.")
     @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "회원가입 성공",
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공",
             content = @Content(schema = @Schema(implementation = UserResponse.class))),
-        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
-        @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 존재하는 이메일")
     })
     @PostMapping("/signup")
-    public ResponseEntity<com.library.module.response.ApiResponse<UserResponse>> signup(
+    public ResponseEntity<ApiResponse<UserResponse>> signup(
             @Valid @RequestBody SignupRequest request) {
         log.info("Signup request received: email={}", request.email());
 
@@ -58,48 +58,48 @@ public class UserController {
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "로그인 성공",
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공",
             content = @Content(schema = @Schema(implementation = TokenResponse.class))),
-        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
-        @ApiResponse(responseCode = "401", description = "인증 실패 (이메일 또는 비밀번호 불일치)")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (이메일 또는 비밀번호 불일치)")
     })
     @PostMapping("/login")
-    public ResponseEntity<com.library.module.response.ApiResponse<TokenResponse>> login(
+    public ResponseEntity<ApiResponse<TokenResponse>> login(
             @Valid @RequestBody LoginRequest request) {
         log.info("Login request received: email={}", request.email());
 
         TokenResponse response = userAuthService.login(request);
 
         return ResponseEntity
-                .ok(com.library.module.response.ApiResponse.success(response));
+                .ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token으로 새로운 Access Token을 발급받습니다.")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
             content = @Content(schema = @Schema(implementation = TokenResponse.class))),
-        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
-        @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token")
     })
     @PostMapping("/reissue")
-    public ResponseEntity<com.library.module.response.ApiResponse<TokenResponse>> reissueToken(
+    public ResponseEntity<ApiResponse<TokenResponse>> reissueToken(
             @Valid @RequestBody TokenReissueRequest request) {
         log.info("Token reissue request received");
 
         TokenResponse response = userAuthService.reissueToken(request);
 
-        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "로그아웃", description = "현재 로그인한 사용자를 로그아웃하고 토큰을 무효화합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 실패 (유효하지 않은 토큰)")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 (유효하지 않은 토큰)")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PostMapping("/logout")
-    public ResponseEntity<com.library.module.response.ApiResponse<Void>> logout(
+    public ResponseEntity<ApiResponse<Void>> logout(
             @RequestHeader("Authorization") String bearerToken) {
         UUID userId = SecurityContextUtil.getCurrentUserId();
         String accessToken = bearerToken.substring(7);
@@ -108,40 +108,40 @@ public class UserController {
 
         userAuthService.logout(accessToken, userId.toString());
 
-        return ResponseEntity.ok(com.library.module.response.ApiResponse.success("로그아웃 되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다."));
     }
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "조회 성공",
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
             content = @Content(schema = @Schema(implementation = UserResponse.class))),
-        @ApiResponse(responseCode = "401", description = "인증 실패"),
-        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @GetMapping("/me")
-    public ResponseEntity<com.library.module.response.ApiResponse<UserResponse>> getMyInfo() {
+    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo() {
         UUID userId = SecurityContextUtil.getCurrentUserId();
 
         log.info("Get my info request received: userId={}", userId);
 
         UserResponse response = userService.getUserById(userId.toString());
 
-        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "회원정보 수정", description = "이름, 전화번호, 주소를 수정합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "수정 성공",
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공",
             content = @Content(schema = @Schema(implementation = UserResponse.class))),
-        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
-        @ApiResponse(responseCode = "401", description = "인증 실패")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PutMapping("/me")
-    public ResponseEntity<com.library.module.response.ApiResponse<UserResponse>> updateUserInfo(
+    public ResponseEntity<ApiResponse<UserResponse>> updateUserInfo(
             @Valid @RequestBody UpdateUserRequest request) {
         UUID userId = SecurityContextUtil.getCurrentUserId();
 
@@ -149,19 +149,19 @@ public class UserController {
 
         UserResponse response = userService.updateUserInfo(userId, request);
 
-        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "비밀번호 변경", description = "현재 비밀번호를 확인하고 새 비밀번호로 변경합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
-        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음 또는 현재 비밀번호 불일치"),
-        @ApiResponse(responseCode = "401", description = "인증 실패")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음 또는 현재 비밀번호 불일치"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @PatchMapping("/me/password")
-    public ResponseEntity<com.library.module.response.ApiResponse<Void>> changePassword(
+    public ResponseEntity<ApiResponse<Void>> changePassword(
             @Valid @RequestBody ChangePasswordRequest request) {
         UUID userId = SecurityContextUtil.getCurrentUserId();
 
@@ -169,15 +169,15 @@ public class UserController {
 
         userService.changePassword(userId, request);
 
-        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     @Operation(summary = "회원 탈퇴", description = "비밀번호를 확인하고 회원을 탈퇴합니다 (Soft Delete).",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공"),
-        @ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음 또는 비밀번호 불일치"),
-        @ApiResponse(responseCode = "401", description = "인증 실패")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "회원 탈퇴 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값이 올바르지 않음 또는 비밀번호 불일치"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @DeleteMapping("/me")
@@ -195,18 +195,18 @@ public class UserController {
     @Operation(summary = "내 쿠폰 조회", description = "현재 로그인한 사용자가 보유한 쿠폰 목록을 조회합니다.",
         security = @SecurityRequirement(name = "bearer-jwt"))
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 실패")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PreAuthorize("hasAnyRole('USER', 'SELLER', 'MASTER')")
     @GetMapping("/me/coupons")
-    public ResponseEntity<com.library.module.response.ApiResponse<List<CouponResponse>>> getMyCoupons() {
+    public ResponseEntity<ApiResponse<List<CouponResponse>>> getMyCoupons() {
         UUID userId = SecurityContextUtil.getCurrentUserId();
 
         log.info("Get my coupons request received: userId={}", userId);
 
         List<CouponResponse> response = userCouponService.getUserCoupons(userId);
 
-        return ResponseEntity.ok(com.library.module.response.ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/user/src/main/java/com/high/user/presentation/internal/WarmupController.java
+++ b/user/src/main/java/com/high/user/presentation/internal/WarmupController.java
@@ -1,0 +1,77 @@
+package com.high.user.presentation.internal;
+
+import com.high.user.infrastructure.persistence.JpaUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * User Service Warmup Controller
+ *
+ * 서비스 재시작 후 Cold Start 문제를 해결하기 위한 Warmup 엔드포인트
+ * Redis 연결 및 Database 연결을 사전 초기화합니다.
+ *
+ * Kubernetes Readiness Probe 및 Docker healthcheck로 사용 가능합니다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class WarmupController {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final JpaUserRepository jpaUserRepository;
+
+    @GetMapping("/warmup")
+    public ResponseEntity<Map<String, Object>> warmup() {
+        log.info("Starting User Service warmup...");
+
+        Map<String, Object> result = new HashMap<>();
+        Map<String, String> components = new HashMap<>();
+
+        try {
+            // Redis warmup
+            components.put("redis", warmupRedis());
+
+            // Database warmup
+            components.put("database", warmupDatabase());
+
+            result.put("status", "success");
+            result.put("components", components);
+            result.put("timestamp", System.currentTimeMillis());
+
+            log.info("User Service warmup completed successfully");
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            log.error("User Service warmup failed", e);
+
+            result.put("status", "failure");
+            result.put("error", e.getMessage());
+            result.put("timestamp", System.currentTimeMillis());
+
+            return ResponseEntity.status(503).body(result);
+        }
+    }
+
+    private String warmupRedis() {
+        // Simple Redis operation to initialize connection pool
+        redisTemplate.opsForValue().get("warmup:user:test");
+        log.info("Redis warmup successful");
+        return "initialized";
+    }
+
+    private String warmupDatabase() {
+        // Simple query to initialize connection pool and JPA
+        long count = jpaUserRepository.count();
+        log.info("Database warmup successful, user count: {}", count);
+        return "initialized";
+    }
+}


### PR DESCRIPTION
## Issue Number
- closed #146

## 📝 Description

서비스 재시작 후 Cold Start 문제를 해결하기 위해 Warmup Endpoint와 자동 초기화 기능을 구현했습니다.

### 배경
- **문제**: 서비스 재시작 후 첫 요청이 11초 소요되어 Circuit Breaker timeout (5초) 초과로 실패
- **원인**: Lazy Initialization으로 인한 지연
  - ReactiveRedisTemplate 첫 연결: 5.6초
  - DispatcherServlet 초기화: 2초
  - JPA/Hibernate 초기화: 1초

### 주요 변경사항

#### 1. Gateway Warmup 구현
- **WarmupController** (`gateway/controller/WarmupController.java`)
  - Redis 연결 초기화
  - TokenBucket 서비스 초기화
  - 엔드포인트: `GET /internal/warmup`

- **WarmupRunner** (`gateway/runner/WarmupRunner.java`)
  - ApplicationRunner 구현
  - 서비스 시작 시 자동 초기화

#### 2. User Service Warmup 구현
- **WarmupController** (`user/presentation/internal/WarmupController.java`)
  - Redis 연결 초기화
  - Database/JPA 초기화
  - 엔드포인트: `GET /internal/warmup`

- **WarmupRunner** (`user/infrastructure/runner/WarmupRunner.java`)
  - ApplicationRunner 구현
  - 서비스 시작 시 자동 초기화

- **Passkey 기능 개선**
  - 패스키 Soft Delete 추가
  - 만료된 패스키 자동 삭제 스케줄러 구현

## 🚀 동작 방식

### ApplicationRunner (자동 초기화)
서비스 시작 시 자동으로 주요 컴포넌트 초기화:
```
=== Gateway Warmup 시작 ===
Redis 연결 초기화 완료
TokenBucket 서비스 초기화 완료
=== Gateway Warmup 완료 (1234ms) ===
```

### Warmup Endpoint (수동 호출)
HTTP 요청으로 초기화 상태 확인:
```bash
curl http://localhost:8000/internal/warmup
# 응답
{
  "status": "success",
  "components": {
    "redis": "initialized",
    "tokenBucket": "initialized"
  },
  "timestamp": 1703345678901
}
```

## 🌐 Test Result

<img width="1423" height="139" alt="image" src="https://github.com/user-attachments/assets/8960ea66-5ac0-4e70-a35f-302f94060eef" />

<img width="1144" height="296" alt="image" src="https://github.com/user-attachments/assets/92174d14-36c8-4a5b-b6f1-5487a6ccfb79" />

## 🔎 To Reviewer

- **ApplicationRunner 자동 초기화**
   - 서비스 시작 시 자동 초기화로 Cold Start 방지
   - 초기화 실패 시에도 서비스는 정상 시작 (로그만 기록)

- **Warmup Endpoint**
   - 수동 호출 시에만 동작